### PR TITLE
Add statistics augmentation: 8 transforms, regression composite, text renderer

### DIFF
--- a/R/addIoLayer.R
+++ b/R/addIoLayer.R
@@ -50,6 +50,9 @@ addIoLayer <- function(myIO,
     transform <- "cumulative"
   }
 
+  # Auto-inject mapping for transforms that produce output columns (Decision #11)
+  mapping <- inject_transform_mapping(transform, mapping)
+
   layer_id <- next_layer_id(existing_layers)
 
   if (is_composite(type)) {
@@ -172,28 +175,38 @@ validate_layer_inputs <- function(type, transform, mapping, label, data, existin
     }
   }
 
-  required_map <- switch(type,
-    treemap = c("level_1", "level_2"),
-    gauge = c("value"),
-    histogram = c("value"),
-    heatmap = c("x_var", "y_var", "value"),
-    candlestick = c("x_var", "open", "high", "low", "close"),
-    waterfall = c("x_var", "y_var"),
-    sankey = c("source", "target", "value"),
-    boxplot = c("x_var", "y_var"),
-    violin = c("x_var", "y_var"),
-    ridgeline = c("x_var", "y_var", "group"),
-    rangeBar = c("x_var", "low_y", "high_y"),
-    area = c("x_var", "low_y", "high_y"),
-    hexbin = c("x_var", "y_var", "radius"),
-    c("x_var", "y_var")
-  )
+  # Override required mapping for transforms that produce output columns
+  transform_contract <- TRANSFORM_INPUT_CONTRACTS[[transform]]
+  if (!is.null(transform_contract)) {
+    required_map <- transform_contract$required_map
+  } else {
+    required_map <- switch(type,
+      treemap = c("level_1", "level_2"),
+      gauge = c("value"),
+      histogram = c("value"),
+      heatmap = c("x_var", "y_var", "value"),
+      candlestick = c("x_var", "open", "high", "low", "close"),
+      waterfall = c("x_var", "y_var"),
+      sankey = c("source", "target", "value"),
+      boxplot = c("x_var", "y_var"),
+      violin = c("x_var", "y_var"),
+      ridgeline = c("x_var", "y_var", "group"),
+      rangeBar = c("x_var", "low_y", "high_y"),
+      area = c("x_var", "low_y", "high_y"),
+      hexbin = c("x_var", "y_var", "radius"),
+      c("x_var", "y_var")
+    )
+  }
   missing_map <- setdiff(required_map, names(mapping))
   if (length(missing_map) > 0) {
     stop("Missing required mapping: ", paste(missing_map, collapse = ", "), call. = FALSE)
   }
 
+  # Fields produced by the transform should be skipped in column-existence checks
+  skip_fields <- if (!is.null(transform_contract)) transform_contract$skip_column_check else character(0)
+
   mapped_fields <- intersect(c("x_var", "y_var", "group", "level_1", "level_2", "value", "low_y", "high_y", "open", "high", "low", "close", "total", "source", "target"), names(mapping))
+  mapped_fields <- setdiff(mapped_fields, skip_fields)
   for (field in mapped_fields) {
     if (!mapping[[field]] %in% colnames(data)) {
       stop("Mapping variable '", mapping[[field]], "' not found in data.", call. = FALSE)
@@ -201,6 +214,7 @@ validate_layer_inputs <- function(type, transform, mapping, label, data, existin
   }
 
   numeric_fields <- intersect(c("y_var", "value", "low_y", "high_y", "open", "high", "low", "close"), names(mapping))
+  numeric_fields <- setdiff(numeric_fields, skip_fields)
   if (type %in% c("line", "point", "bar", "hexbin", "area", "groupedBar", "histogram", "gauge", "donut", "candlestick", "waterfall", "sankey", "violin")) {
     for (nf in numeric_fields) {
       if (!is.numeric(data[[mapping[[nf]]]])) {
@@ -287,4 +301,30 @@ build_grouped_layers <- function(data, mapping, type, label, color, transform_fn
   }
 
   layers
+}
+
+# Transform input contracts: override validation for transforms that produce output columns
+TRANSFORM_INPUT_CONTRACTS <- list(
+  ci = list(
+    required_map = c("x_var", "y_var"),
+    skip_column_check = c("low_y", "high_y"),
+    auto_mapping = list(low_y = "low_y", high_y = "high_y")
+  ),
+  mean_ci = list(
+    required_map = c("x_var", "y_var"),
+    skip_column_check = c("low_y", "high_y"),
+    auto_mapping = list(low_y = "low_y", high_y = "high_y")
+  )
+)
+
+inject_transform_mapping <- function(transform, mapping) {
+  contract <- TRANSFORM_INPUT_CONTRACTS[[transform]]
+  if (!is.null(contract) && !is.null(contract$auto_mapping)) {
+    for (field in names(contract$auto_mapping)) {
+      if (is.null(mapping[[field]])) {
+        mapping[[field]] <- contract$auto_mapping[[field]]
+      }
+    }
+  }
+  mapping
 }

--- a/R/composite_regression.R
+++ b/R/composite_regression.R
@@ -1,0 +1,115 @@
+#' Regression composite
+#'
+#' Expands into scatter + trend line + CI band + R² annotation sublayers.
+#'
+#' @keywords internal
+composite_regression <- function(data, mapping, label, color, options) {
+  method <- if (is.null(options$method)) "lm" else options$method
+  show_ci <- if (is.null(options$showCI)) TRUE else isTRUE(options$showCI)
+  show_stats <- if (is.null(options$showStats)) TRUE else isTRUE(options$showStats)
+  level <- if (is.null(options$level)) 0.95 else options$level
+  interval <- if (is.null(options$interval)) "confidence" else options$interval
+
+  # Determine groups
+  has_group <- !is.null(mapping$group) && mapping$group %in% colnames(data)
+  if (has_group) {
+    group_vals <- unique(data[[mapping$group]])
+  } else {
+    group_vals <- list(NULL)
+  }
+
+  sublayers <- list()
+
+  for (gv in group_vals) {
+    if (!is.null(gv)) {
+      group_data <- data[data[[mapping$group]] == gv, , drop = FALSE]
+      group_label <- paste0(label, " \u2014 ", as.character(gv))
+    } else {
+      group_data <- data
+      group_label <- label
+    }
+
+    # 1. Scatter points
+    sublayers[[length(sublayers) + 1L]] <- list(
+      type = "point", role = "scatter",
+      label = paste0(group_label, " (data)"),
+      data = group_data, mapping = mapping, transform = "identity",
+      color = color, options = list()
+    )
+
+    # 2. Trend line
+    sublayers[[length(sublayers) + 1L]] <- list(
+      type = "line", role = "trend",
+      label = paste0(group_label, " (trend)"),
+      data = group_data, mapping = mapping, transform = method,
+      color = color, options = options
+    )
+
+    # 3. CI band
+    if (show_ci) {
+      sublayers[[length(sublayers) + 1L]] <- list(
+        type = "area", role = "ci_band",
+        label = paste0(group_label, " (CI)"),
+        data = group_data,
+        mapping = list(x_var = mapping$x_var, y_var = mapping$y_var,
+                       low_y = "low_y", high_y = "high_y"),
+        transform = "ci",
+        color = color,
+        options = list(method = method, level = level, interval = interval,
+                       span = options$span, degree = options$degree)
+      )
+    }
+
+    # 4. R² annotation (lm/polynomial only, first group only)
+    if (show_stats && length(sublayers) <= 4 && method %in% c("lm", "polynomial")) {
+      x_vals <- group_data[[mapping$x_var]]
+      y_vals <- group_data[[mapping$y_var]]
+      complete <- !is.na(x_vals) & !is.na(y_vals)
+      if (sum(complete) >= 3L) {
+        x_clean <- x_vals[complete]
+        y_clean <- y_vals[complete]
+        model <- if (method == "lm") {
+          stats::lm(y_clean ~ x_clean)
+        } else {
+          stats::lm(y_clean ~ stats::poly(x_clean,
+            degree = if (is.null(options$degree)) 2L else options$degree,
+            raw = TRUE))
+        }
+        r_sq <- summary(model)$r.squared
+        coefs <- stats::coef(model)
+
+        eq_text <- if (method == "lm") {
+          sprintf("y = %sx + %s",
+                  format(round(coefs[2], 3), nsmall = 3),
+                  format(round(coefs[1], 3), nsmall = 3))
+        } else {
+          paste0("poly(", if (is.null(options$degree)) 2L else options$degree, ")")
+        }
+
+        annotation_data <- data.frame(
+          text = c(
+            paste0("R\u00B2 = ", format(round(r_sq, 3), nsmall = 3)),
+            eq_text
+          ),
+          stringsAsFactors = FALSE
+        )
+        annotation_data[["_source_key"]] <- paste0("annotation_", seq_len(nrow(annotation_data)))
+
+        sublayers[[length(sublayers) + 1L]] <- list(
+          type = "text", role = "annotation",
+          label = paste0(group_label, " (stats)"),
+          data = annotation_data, mapping = list(),
+          transform = "identity", color = NULL,
+          options = list(position = "top-right"),
+          scaleHints = list(
+            xScaleType = "linear", yScaleType = "linear",
+            xExtentFields = list(), yExtentFields = list(),
+            domainMerge = "union"
+          )
+        )
+      }
+    }
+  }
+
+  sublayers
+}

--- a/R/transform_ci.R
+++ b/R/transform_ci.R
@@ -1,0 +1,70 @@
+#' Confidence / prediction interval transform
+#'
+#' @keywords internal
+transform_ci <- function(data, mapping, options = list()) {
+  method <- if (is.null(options$method)) "lm" else options$method
+  level <- if (is.null(options$level)) 0.95 else options$level
+  interval <- if (is.null(options$interval)) "confidence" else options$interval
+  n_grid <- if (is.null(options$n_grid)) 100L else options$n_grid
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  if (length(x_clean) < 3L) {
+    warning("transform_ci requires at least 3 data points; returning empty.",
+            call. = FALSE)
+    empty <- data.frame(
+      x = numeric(0), low_y = numeric(0), high_y = numeric(0),
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+    colnames(empty)[1] <- mapping$x_var
+    return(list(
+      data = empty,
+      meta = new_transform_meta("ci", list(
+        sourceKeys = list(), derivedFrom = "input_rows"
+      ))
+    ))
+  }
+
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+
+  if (method == "lm") {
+    model <- stats::lm(y_clean ~ x_clean)
+    preds <- stats::predict(model,
+      newdata = data.frame(x_clean = grid_x),
+      interval = interval, level = level)
+    transformed <- data.frame(
+      x = grid_x, low_y = preds[, "lwr"], high_y = preds[, "upr"],
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else if (method == "loess") {
+    span <- if (is.null(options$span)) 0.75 else options$span
+    model <- stats::loess(y_clean ~ x_clean, span = span)
+    preds <- stats::predict(model,
+      newdata = data.frame(x_clean = grid_x), se = TRUE)
+    alpha <- 1 - level
+    df <- model$enp - 1
+    t_crit <- stats::qt(1 - alpha / 2, df = max(df, 1))
+    transformed <- data.frame(
+      x = grid_x,
+      low_y = preds$fit - t_crit * preds$se.fit,
+      high_y = preds$fit + t_crit * preds$se.fit,
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else {
+    stop("Unknown ci method '", method, "'. Must be 'lm' or 'loess'.",
+         call. = FALSE)
+  }
+
+  colnames(transformed)[1] <- mapping$x_var
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("ci", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_loess.R
+++ b/R/transform_loess.R
@@ -1,0 +1,49 @@
+#' LOESS smoothing transform
+#'
+#' @keywords internal
+transform_loess <- function(data, mapping, options = list()) {
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  if (length(x_clean) < 4L) {
+    warning("transform_loess requires at least 4 data points; returning empty.",
+            call. = FALSE)
+    empty <- data.frame(
+      x = numeric(0), y = numeric(0), `_source_key` = character(0),
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+    colnames(empty)[1:2] <- c(mapping$x_var, mapping$y_var)
+    return(list(
+      data = empty,
+      meta = new_transform_meta("loess", list(
+        sourceKeys = list(), derivedFrom = "input_rows"
+      ))
+    ))
+  }
+
+  span <- if (is.null(options$span)) 0.75 else options$span
+  degree <- if (is.null(options$degree)) 2L else options$degree
+  n_grid <- if (is.null(options$n_grid)) 100L else options$n_grid
+
+  model <- stats::loess(y_clean ~ x_clean, span = span, degree = degree)
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+  fitted_y <- stats::predict(model, newdata = data.frame(x_clean = grid_x))
+
+  transformed <- data.frame(
+    x = grid_x, y = fitted_y,
+    `_source_key` = sprintf("grid_%d", seq_len(n_grid)),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("loess", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_mean.R
+++ b/R/transform_mean.R
@@ -1,0 +1,34 @@
+#' Mean transform
+#'
+#' @keywords internal
+transform_mean <- function(data, mapping, options = list()) {
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  summarize_group <- function(group_value) {
+    group_y <- y_values[x_values == group_value]
+    group_y <- group_y[!is.na(group_y)]
+    data.frame(
+      x = group_value,
+      y = if (length(group_y) == 0L) NA_real_ else mean(group_y),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("mean", list(
+      sourceKeys = source_keys,
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_mean_ci.R
+++ b/R/transform_mean_ci.R
@@ -1,0 +1,55 @@
+#' Group mean with confidence interval transform
+#'
+#' @keywords internal
+transform_mean_ci <- function(data, mapping, options = list()) {
+  level <- if (is.null(options$level)) 0.95 else options$level
+  method <- if (is.null(options$method)) "t" else options$method
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  summarize_group <- function(gv) {
+    group_y <- y_values[x_values == gv]
+    group_y <- group_y[!is.na(group_y)]
+    n <- length(group_y)
+
+    if (n < 2L) {
+      return(data.frame(
+        x = gv,
+        y = if (n == 1L) group_y else NA_real_,
+        low_y = NA_real_, high_y = NA_real_,
+        n = n, se = NA_real_,
+        stringsAsFactors = FALSE, check.names = FALSE
+      ))
+    }
+
+    m <- mean(group_y)
+    se <- stats::sd(group_y) / sqrt(n)
+    margin <- if (method == "t") {
+      stats::qt(1 - (1 - level) / 2, df = n - 1) * se
+    } else {
+      stats::qnorm(1 - (1 - level) / 2) * se
+    }
+
+    data.frame(
+      x = gv, y = m, low_y = m - margin, high_y = m + margin,
+      n = n, se = se,
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("mean_ci", list(
+      sourceKeys = source_keys,
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_polynomial.R
+++ b/R/transform_polynomial.R
@@ -1,0 +1,48 @@
+#' Polynomial regression transform
+#'
+#' @keywords internal
+transform_polynomial <- function(data, mapping, options = list()) {
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  degree <- if (is.null(options$degree)) 2L else options$degree
+  n_grid <- if (is.null(options$n_grid)) 100L else options$n_grid
+
+  if (length(x_clean) <= degree) {
+    warning("transform_polynomial requires more data points than degree; returning empty.",
+            call. = FALSE)
+    empty <- data.frame(
+      x = numeric(0), y = numeric(0), `_source_key` = character(0),
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+    colnames(empty)[1:2] <- c(mapping$x_var, mapping$y_var)
+    return(list(
+      data = empty,
+      meta = new_transform_meta("polynomial", list(
+        sourceKeys = list(), derivedFrom = "input_rows"
+      ))
+    ))
+  }
+
+  model <- stats::lm(y_clean ~ stats::poly(x_clean, degree = degree, raw = TRUE))
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+  fitted_y <- stats::predict(model, newdata = data.frame(x_clean = grid_x))
+
+  transformed <- data.frame(
+    x = grid_x, y = fitted_y,
+    `_source_key` = sprintf("grid_%d", seq_len(n_grid)),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("polynomial", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_registry.R
+++ b/R/transform_registry.R
@@ -9,7 +9,15 @@ transform_registry <- function() {
     quantiles = transform_quantiles,
     median = transform_median,
     outliers = transform_outliers,
-    density = transform_density
+    density = transform_density,
+    mean = transform_mean,
+    summary = transform_summary,
+    loess = transform_loess,
+    polynomial = transform_polynomial,
+    smooth = transform_smooth,
+    residuals = transform_residuals,
+    ci = transform_ci,
+    mean_ci = transform_mean_ci
   )
 }
 

--- a/R/transform_residuals.R
+++ b/R/transform_residuals.R
@@ -1,0 +1,38 @@
+#' Regression residuals transform
+#'
+#' @keywords internal
+transform_residuals <- function(data, mapping, options = list()) {
+  method <- if (is.null(options$method)) "lm" else options$method
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  model <- switch(method,
+    lm = stats::lm(y_clean ~ x_clean),
+    loess = stats::loess(y_clean ~ x_clean,
+      span = if (is.null(options$span)) 0.75 else options$span),
+    polynomial = stats::lm(y_clean ~ stats::poly(x_clean,
+      degree = if (is.null(options$degree)) 2L else options$degree, raw = TRUE)),
+    stop("Unknown residuals method '", method, "'.", call. = FALSE)
+  )
+
+  resid_vals <- stats::residuals(model)
+  fitted_vals <- stats::fitted(model)
+
+  transformed <- data.frame(
+    x = fitted_vals, y = resid_vals,
+    `_source_key` = as.character(data[["_source_key"]][complete]),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("residuals", list(
+      sourceKeys = as.list(transformed[["_source_key"]]),
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_smooth.R
+++ b/R/transform_smooth.R
@@ -1,0 +1,54 @@
+#' Moving average / exponential smoothing transform
+#'
+#' @keywords internal
+transform_smooth <- function(data, mapping, options = list()) {
+  method <- if (is.null(options$method)) "sma" else options$method
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+
+  ord <- order(x_vals)
+  x_sorted <- x_vals[ord]
+  y_sorted <- y_vals[ord]
+  keys_sorted <- as.character(data[["_source_key"]][ord])
+
+  if (method == "sma") {
+    window <- if (is.null(options$window)) 7L else options$window
+    if (window > length(y_sorted)) {
+      warning("transform_smooth window (", window, ") exceeds data length (",
+              length(y_sorted), "); clamping.", call. = FALSE)
+      window <- length(y_sorted)
+    }
+    smoothed <- stats::filter(y_sorted, rep(1 / window, window), sides = 2)
+    keep <- !is.na(smoothed)
+    transformed <- data.frame(
+      x = x_sorted[keep], y = as.numeric(smoothed[keep]),
+      `_source_key` = keys_sorted[keep],
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else if (method == "ema") {
+    alpha <- if (is.null(options$alpha)) 0.3 else options$alpha
+    ema <- numeric(length(y_sorted))
+    ema[1] <- y_sorted[1]
+    for (i in seq(2, length(y_sorted))) {
+      ema[i] <- alpha * y_sorted[i] + (1 - alpha) * ema[i - 1]
+    }
+    transformed <- data.frame(
+      x = x_sorted, y = ema,
+      `_source_key` = keys_sorted,
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else {
+    stop("Unknown smooth method '", method, "'. Must be 'sma' or 'ema'.",
+         call. = FALSE)
+  }
+
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("smooth", list(
+      sourceKeys = as.list(transformed[["_source_key"]]),
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/transform_summary.R
+++ b/R/transform_summary.R
@@ -1,0 +1,45 @@
+#' Summary statistics transform
+#'
+#' @keywords internal
+transform_summary <- function(data, mapping, options = list()) {
+  stat <- if (is.null(options$stat)) "count" else options$stat
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  stat_fn <- switch(stat,
+    count = function(y) length(y[!is.na(y)]),
+    sum   = function(y) sum(y, na.rm = TRUE),
+    sd    = function(y) stats::sd(y, na.rm = TRUE),
+    var   = function(y) stats::var(y, na.rm = TRUE),
+    min   = function(y) min(y, na.rm = TRUE),
+    max   = function(y) max(y, na.rm = TRUE),
+    stop("Unknown stat '", stat, "'. Must be one of: count, sum, sd, var, min, max.",
+         call. = FALSE)
+  )
+
+  summarize_group <- function(gv) {
+    group_y <- y_values[x_values == gv]
+    data.frame(
+      x = gv,
+      y = stat_fn(group_y),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("summary", list(
+      sourceKeys = source_keys,
+      derivedFrom = "input_rows"
+    ))
+  )
+}

--- a/R/util.R
+++ b/R/util.R
@@ -28,7 +28,7 @@ ALLOWED_TYPES <- c(
   "line", "point", "bar", "hexbin", "treemap", "gauge",
   "donut", "area", "groupedBar", "histogram", "heatmap",
   "candlestick", "waterfall", "sankey", "boxplot", "violin",
-  "ridgeline", "rangeBar"
+  "ridgeline", "rangeBar", "text", "regression"
 )
 
 COMPATIBILITY_GROUPS <- list(
@@ -49,7 +49,9 @@ COMPATIBILITY_GROUPS <- list(
   hexbin = "axes-hex",
   treemap = "standalone-treemap",
   donut = "standalone-donut",
-  gauge = "standalone-gauge"
+  gauge = "standalone-gauge",
+  text = "axes-continuous",
+  regression = "axes-continuous"
 )
 
 GROUP_MATRIX <- list(
@@ -65,10 +67,10 @@ GROUP_MATRIX <- list(
 )
 
 VALID_COMBINATIONS <- list(
-  line = c("identity", "lm"),
-  point = c("identity"),
-  area = c("identity"),
-  bar = c("identity"),
+  line = c("identity", "lm", "loess", "polynomial", "smooth"),
+  point = c("identity", "mean", "summary", "residuals"),
+  area = c("identity", "ci"),
+  bar = c("identity", "mean", "summary"),
   groupedBar = c("identity"),
   histogram = c("identity"),
   heatmap = c("identity"),
@@ -78,18 +80,20 @@ VALID_COMBINATIONS <- list(
   boxplot = c("identity"),
   violin = c("identity"),
   ridgeline = c("identity"),
-  rangeBar = c("identity"),
+  rangeBar = c("identity", "mean_ci"),
   hexbin = c("identity"),
   treemap = c("identity"),
   donut = c("identity"),
-  gauge = c("identity")
+  gauge = c("identity"),
+  text = c("identity")
 )
 
 composite_registry <- function() {
   list(
     boxplot = composite_boxplot,
     violin = composite_violin,
-    ridgeline = composite_ridgeline
+    ridgeline = composite_ridgeline,
+    regression = composite_regression
   )
 }
 

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -47,7 +47,8 @@
       linePath.merge(newLinePath).transition().ease(d3.easeQuad).duration(transitionSpeed).style("opacity", 1).style("stroke-width", strokeWidth(chart)).style("stroke", function(d) {
         return resolveColor(chart, d[0][layer.mapping.group], layer.color);
       }).attr("d", valueLine);
-      if (layer.transform !== "lm") {
+      var fittingTransforms = ["lm", "loess", "polynomial", "smooth"];
+      if (fittingTransforms.indexOf(layer.transform) === -1) {
         this.renderPoints(chart, layer);
       }
     }
@@ -2282,6 +2283,52 @@
     }
   };
 
+  // inst/htmlwidgets/myIO/src/renderers/TextRenderer.js
+  var TextRenderer = class {
+    static type = "text";
+    static traits = {
+      hasAxes: false,
+      referenceLines: false,
+      legendType: "none",
+      binning: false,
+      rolloverStyle: "none",
+      scaleCapabilities: { invertX: false }
+    };
+    static scaleHints = {
+      xScaleType: "linear",
+      yScaleType: "linear",
+      xExtentFields: [],
+      yExtentFields: [],
+      domainMerge: "union"
+    };
+    static dataContract = {};
+    render(chart, layer) {
+      var position = layer.options && layer.options.position || "top-right";
+      var key = layer.label;
+      var className = tagName("text-annotation", chart.element.id, key);
+      chart.chart.selectAll("." + className).remove();
+      var lines = layer.data.map(function(d) {
+        return d.text;
+      });
+      var isTop = position.indexOf("top") !== -1;
+      var isRight = position.indexOf("right") !== -1;
+      var x = isRight ? chart.width - 10 : 10;
+      var y = isTop ? 20 : chart.height - 10;
+      var anchor = isRight ? "end" : "start";
+      var g = chart.chart.append("g").attr("class", className).attr("transform", "translate(" + x + "," + y + ")");
+      lines.forEach(function(line, i) {
+        g.append("text").attr("y", (isTop ? 1 : -1) * i * 16).attr("text-anchor", anchor).style("font-size", "12px").style("font-family", "var(--font-family, sans-serif)").style("fill", "var(--text-color, #333)").style("opacity", 0.8).text(line);
+      });
+    }
+    formatTooltip() {
+      return null;
+    }
+    remove(chart, layer) {
+      var className = tagName("text-annotation", chart.dom.element.id, layer.label);
+      chart.dom.chartArea.selectAll("." + className).remove();
+    }
+  };
+
   // inst/htmlwidgets/myIO/src/registry.js
   var rendererRegistry = /* @__PURE__ */ new Map();
   function registerRenderer(type, RendererClass) {
@@ -2354,6 +2401,9 @@
     }
     if (!rendererRegistry.has(RangeBarRenderer.type)) {
       registerRenderer(RangeBarRenderer.type, new RangeBarRenderer());
+    }
+    if (!rendererRegistry.has(TextRenderer.type)) {
+      registerRenderer(TextRenderer.type, new TextRenderer());
     }
     return rendererRegistry;
   }
@@ -2816,7 +2866,14 @@
     var scaleSemantics = semantics || {};
     var globalXExtentFields = scaleSemantics.xExtentFields || ["x_var"];
     var yExtentFields = scaleSemantics.yExtentFields || ["y_var"];
-    lys.forEach(function(d) {
+    var scaleLayers = lys.filter(function(layer) {
+      var hints = layer.scaleHints;
+      if (hints && Array.isArray(hints.xExtentFields) && hints.xExtentFields.length === 0 && Array.isArray(hints.yExtentFields) && hints.yExtentFields.length === 0) {
+        return false;
+      }
+      return true;
+    });
+    scaleLayers.forEach(function(d) {
       var layerXFields = d.scaleHints && Array.isArray(d.scaleHints.xExtentFields) ? d.scaleHints.xExtentFields : globalXExtentFields;
       var xValues = [];
       layerXFields.forEach(function(field) {

--- a/inst/htmlwidgets/myIO/src/derive/scales.js
+++ b/inst/htmlwidgets/myIO/src/derive/scales.js
@@ -56,7 +56,17 @@ export function processScales(chart, lys, semantics) {
   var globalXExtentFields = scaleSemantics.xExtentFields || ["x_var"];
   var yExtentFields = scaleSemantics.yExtentFields || ["y_var"];
 
-  lys.forEach(function(d) {
+  // Filter out non-axes layers (e.g. text annotations) from scale computation
+  var scaleLayers = lys.filter(function(layer) {
+    var hints = layer.scaleHints;
+    if (hints && Array.isArray(hints.xExtentFields) && hints.xExtentFields.length === 0
+        && Array.isArray(hints.yExtentFields) && hints.yExtentFields.length === 0) {
+      return false;
+    }
+    return true;
+  });
+
+  scaleLayers.forEach(function(d) {
     var layerXFields = (d.scaleHints && Array.isArray(d.scaleHints.xExtentFields))
       ? d.scaleHints.xExtentFields
       : globalXExtentFields;

--- a/inst/htmlwidgets/myIO/src/registry.js
+++ b/inst/htmlwidgets/myIO/src/registry.js
@@ -15,6 +15,7 @@ import { CandlestickRenderer } from "./renderers/CandlestickRenderer.js";
 import { WaterfallRenderer } from "./renderers/WaterfallRenderer.js";
 import { SankeyRenderer } from "./renderers/SankeyRenderer.js";
 import { RangeBarRenderer } from "./renderers/RangeBarRenderer.js";
+import { TextRenderer } from "./renderers/TextRenderer.js";
 
 export function registerRenderer(type, RendererClass) {
   if (rendererRegistry.has(type)) {
@@ -92,6 +93,10 @@ export function registerBuiltInRenderers() {
   }
   if (!rendererRegistry.has(RangeBarRenderer.type)) {
     registerRenderer(RangeBarRenderer.type, new RangeBarRenderer());
+  }
+
+  if (!rendererRegistry.has(TextRenderer.type)) {
+    registerRenderer(TextRenderer.type, new TextRenderer());
   }
 
   return rendererRegistry;

--- a/inst/htmlwidgets/myIO/src/renderers/LineRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/LineRenderer.js
@@ -49,7 +49,8 @@ export class LineRenderer {
       })
       .attr("d", valueLine);
 
-    if (layer.transform !== "lm") {
+    var fittingTransforms = ["lm", "loess", "polynomial", "smooth"];
+    if (fittingTransforms.indexOf(layer.transform) === -1) {
       this.renderPoints(chart, layer);
     }
   }

--- a/inst/htmlwidgets/myIO/src/renderers/TextRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/TextRenderer.js
@@ -1,0 +1,60 @@
+import { tagName } from "../utils/responsive.js";
+
+export class TextRenderer {
+  static type = "text";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "none",
+    binning: false,
+    rolloverStyle: "none",
+    scaleCapabilities: { invertX: false }
+  };
+  static scaleHints = {
+    xScaleType: "linear",
+    yScaleType: "linear",
+    xExtentFields: [],
+    yExtentFields: [],
+    domainMerge: "union"
+  };
+  static dataContract = {};
+
+  render(chart, layer) {
+    var position = (layer.options && layer.options.position) || "top-right";
+    var key = layer.label;
+    var className = tagName("text-annotation", chart.element.id, key);
+
+    chart.chart.selectAll("." + className).remove();
+
+    var lines = layer.data.map(function(d) { return d.text; });
+
+    var isTop = position.indexOf("top") !== -1;
+    var isRight = position.indexOf("right") !== -1;
+
+    var x = isRight ? chart.width - 10 : 10;
+    var y = isTop ? 20 : chart.height - 10;
+    var anchor = isRight ? "end" : "start";
+
+    var g = chart.chart.append("g")
+      .attr("class", className)
+      .attr("transform", "translate(" + x + "," + y + ")");
+
+    lines.forEach(function(line, i) {
+      g.append("text")
+        .attr("y", (isTop ? 1 : -1) * i * 16)
+        .attr("text-anchor", anchor)
+        .style("font-size", "12px")
+        .style("font-family", "var(--font-family, sans-serif)")
+        .style("fill", "var(--text-color, #333)")
+        .style("opacity", 0.8)
+        .text(line);
+    });
+  }
+
+  formatTooltip() { return null; }
+
+  remove(chart, layer) {
+    var className = tagName("text-annotation", chart.dom.element.id, layer.label);
+    chart.dom.chartArea.selectAll("." + className).remove();
+  }
+}

--- a/md/archive/statistics-augmentation-contract.md
+++ b/md/archive/statistics-augmentation-contract.md
@@ -1,0 +1,100 @@
+# Statistics Augmentation — Layer Contract
+
+Design doc: `docs/statistics-augmentation-design.md`
+
+## Transforms
+
+| Transform | R function | Registry key | Output shape | Compatible types |
+|-----------|-----------|--------------|-------------|-----------------|
+| Confidence interval | `transform_ci` | `ci` | grid: `{x_var}`, `low_y`, `high_y` | area |
+| LOESS smoothing | `transform_loess` | `loess` | grid: `{x_var}`, `{y_var}`, `_source_key` | line |
+| Polynomial regression | `transform_polynomial` | `polynomial` | grid: `{x_var}`, `{y_var}`, `_source_key` | line |
+| Group mean | `transform_mean` | `mean` | agg: `{x_var}`, `{y_var}` | point, bar |
+| Mean ± CI | `transform_mean_ci` | `mean_ci` | agg: `{x_var}`, `{y_var}`, `low_y`, `high_y`, `n`, `se` | rangeBar |
+| Moving average | `transform_smooth` | `smooth` | series: `{x_var}`, `{y_var}`, `_source_key` | line |
+| Residuals | `transform_residuals` | `residuals` | series: `{x_var}`, `{y_var}`, `_source_key` | point |
+| Summary stats | `transform_summary` | `summary` | agg: `{x_var}`, `{y_var}` | point, bar |
+
+## Transform Options
+
+| Transform | Option | R field | Default | Type |
+|-----------|--------|---------|---------|------|
+| ci | method | `options$method` | `"lm"` | `"lm"` \| `"loess"` |
+| ci | level | `options$level` | `0.95` | numeric (0,1) |
+| ci | interval | `options$interval` | `"confidence"` | `"confidence"` \| `"prediction"` |
+| ci | n_grid | `options$n_grid` | `100` | integer |
+| ci | span | `options$span` | `0.75` | numeric (for loess method) |
+| loess | span | `options$span` | `0.75` | numeric |
+| loess | degree | `options$degree` | `2` | 1 \| 2 |
+| loess | n_grid | `options$n_grid` | `100` | integer |
+| polynomial | degree | `options$degree` | `2` | integer ≥ 2 |
+| polynomial | n_grid | `options$n_grid` | `100` | integer |
+| mean_ci | level | `options$level` | `0.95` | numeric (0,1) |
+| mean_ci | method | `options$method` | `"t"` | `"t"` \| `"se"` |
+| smooth | method | `options$method` | `"sma"` | `"sma"` \| `"ema"` |
+| smooth | window | `options$window` | `7` | integer (for sma) |
+| smooth | alpha | `options$alpha` | `0.3` | numeric (0,1) (for ema) |
+| residuals | method | `options$method` | `"lm"` | `"lm"` \| `"loess"` \| `"polynomial"` |
+| residuals | degree | `options$degree` | `2` | integer (for polynomial) |
+| residuals | span | `options$span` | `0.75` | numeric (for loess) |
+| summary | stat | `options$stat` | `"count"` | `"count"` \| `"sum"` \| `"sd"` \| `"var"` \| `"min"` \| `"max"` |
+
+## Composite
+
+| Composite | R function | Registry key | Sublayers |
+|-----------|-----------|--------------|-----------|
+| Regression | `composite_regression` | `regression` | scatter (point/identity), trend (line/lm\|loess\|polynomial), ci_band (area/ci), annotation (text/identity) |
+
+## Composite Options
+
+| Option | R field | Default | Type |
+|--------|---------|---------|------|
+| method | `options$method` | `"lm"` | `"lm"` \| `"loess"` \| `"polynomial"` |
+| showCI | `options$showCI` | `TRUE` | logical |
+| level | `options$level` | `0.95` | numeric |
+| interval | `options$interval` | `"confidence"` | `"confidence"` \| `"prediction"` |
+| showStats | `options$showStats` | `TRUE` | logical |
+| degree | `options$degree` | `2` | integer |
+| span | `options$span` | `0.75` | numeric |
+
+## JS Renderer
+
+| Renderer | JS class | Registry key | Traits |
+|----------|----------|-------------|--------|
+| Text annotation | `TextRenderer` | `text` | hasAxes: false, legendType: "none", rolloverStyle: "none" |
+
+## Output Column Names (canonical)
+
+These column names are the contract between R transforms and JS renderers:
+
+| Column | Used by | Meaning |
+|--------|---------|---------|
+| `low_y` | ci, mean_ci → AreaRenderer, RangeBarRenderer | Lower bound |
+| `high_y` | ci, mean_ci → AreaRenderer, RangeBarRenderer | Upper bound |
+| `n` | mean_ci | Group sample size |
+| `se` | mean_ci | Standard error |
+| `text` | TextRenderer | Annotation text content |
+| `position` | TextRenderer | Corner position string |
+
+## Registry Updates
+
+### ALLOWED_TYPES additions
+`"text"`, `"regression"`
+
+### VALID_COMBINATIONS additions
+| Type | Add transforms |
+|------|---------------|
+| line | `"loess"`, `"polynomial"`, `"smooth"` |
+| point | `"mean"`, `"summary"`, `"residuals"` |
+| area | `"ci"` |
+| bar | `"mean"`, `"summary"` |
+| rangeBar | `"mean_ci"` |
+
+### COMPATIBILITY_GROUPS additions
+| Type | Group |
+|------|-------|
+| text | `"axes-continuous"` |
+| regression | `"axes-continuous"` |
+
+### addIoLayer auto-mapping
+When `transform == "ci"` and `type == "area"`: auto-inject `low_y = "low_y"`, `high_y = "high_y"` into mapping if absent. (Per Decision #11)

--- a/md/archive/statistics-augmentation-plan.md
+++ b/md/archive/statistics-augmentation-plan.md
@@ -1,0 +1,1007 @@
+# Implementation Plan: Statistics Augmentation
+
+Design doc: `docs/statistics-augmentation-design.md`
+Contract: `md/design/statistics-augmentation-contract.md`
+
+## Blocker Resolutions
+
+Three blockers identified in quality review; each resolved before phasing:
+
+**B1+B2: Validation incompatible with transform-produced columns.**
+`validate_layer_inputs` (addIoLayer.R:175-228) checks that mapped fields exist as columns in the user's *input* data. Transforms like `ci` and `mean_ci` produce `low_y`/`high_y` columns that don't exist in input data. Fix: add a `TRANSFORM_INPUT_CONTRACTS` map that overrides `required_map` and skips column-existence checks for transform-produced fields. Auto-injection of `low_y`/`high_y` into mapping happens AFTER validation, BEFORE transform execution.
+
+**B3: TextRenderer pollutes scale computation.**
+`processScales` (scales.js) iterates all layers without filtering by `hasAxes`. A text layer with no `x_var`/`y_var` mapping produces `NaN` in extent arrays, breaking `d3.extent`. Fix: filter out layers where `renderer.constructor.traits.hasAxes === false` before passing to `processScales`.
+
+## Warning Resolutions
+
+**W4: composite_regression must split by group.** Add group iteration loop (see Phase 4).
+**W5-W8: Edge cases.** Each transform validates minimum data requirements and returns empty data frame + warning on degenerate input (see per-transform specs).
+**W9: LineRenderer shows points on fitted curves.** Change condition from `layer.transform !== "lm"` to check against a list of fitting transforms.
+
+---
+
+## Phase 1: Foundation transforms (no JS changes)
+
+Gate: `devtools::test()` passes, `R CMD check` clean.
+
+### 1a. `transform_mean` — Group mean
+
+**Create** `R/transform_mean.R`:
+
+```r
+transform_mean <- function(data, mapping, options = list()) {
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  summarize_group <- function(group_value) {
+    group_y <- y_values[x_values == group_value]
+    group_y <- group_y[!is.na(group_y)]
+    data.frame(
+      x = group_value,
+      y = if (length(group_y) == 0L) NA_real_ else mean(group_y),
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("mean", list(
+      sourceKeys = source_keys, derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_mean.R`:
+- "computes correct group means"
+- "handles NA values with na.rm"
+- "returns NA for empty group"
+- "single group returns that group's mean"
+- "mean matches median for symmetric data"
+
+### 1b. `transform_summary` — General aggregation
+
+**Create** `R/transform_summary.R`:
+
+```r
+transform_summary <- function(data, mapping, options = list()) {
+  stat <- options$stat %||% "count"
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  stat_fn <- switch(stat,
+    count = function(y) length(y[!is.na(y)]),
+    sum   = function(y) sum(y, na.rm = TRUE),
+    sd    = function(y) stats::sd(y, na.rm = TRUE),
+    var   = function(y) stats::var(y, na.rm = TRUE),
+    min   = function(y) min(y, na.rm = TRUE),
+    max   = function(y) max(y, na.rm = TRUE),
+    stop("Unknown stat '", stat, "'. Must be one of: count, sum, sd, var, min, max.", call. = FALSE)
+  )
+
+  summarize_group <- function(gv) {
+    group_y <- y_values[x_values == gv]
+    data.frame(x = gv, y = stat_fn(group_y),
+               stringsAsFactors = FALSE, check.names = FALSE)
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("summary", list(
+      sourceKeys = source_keys, derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_summary.R`:
+- "count returns number of non-NA values per group"
+- "sum returns correct totals"
+- "sd returns correct standard deviation"
+- "unknown stat errors with clear message"
+- "handles all-NA group"
+
+### 1c. Update registry and validation
+
+**Edit** `R/transform_registry.R` — add `mean = transform_mean, summary = transform_summary` to registry.
+
+**Edit** `R/util.R`:
+- `VALID_COMBINATIONS$point`: add `"mean"`, `"summary"`
+- `VALID_COMBINATIONS$bar`: add `"mean"`, `"summary"`
+
+### 1d. Verification
+
+```
+devtools::test()
+R CMD check --no-manual
+```
+
+---
+
+## Phase 2: Regression transforms
+
+Gate: `devtools::test()` passes. Manual visual check: LOESS line on scatter plot.
+
+### 2a. `transform_loess` — LOESS smoothing
+
+**Create** `R/transform_loess.R`:
+
+```r
+transform_loess <- function(data, mapping, options = list()) {
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  if (length(x_clean) < 4L) {
+    warning("transform_loess requires at least 4 data points; returning empty.", call. = FALSE)
+    empty <- data.frame(x = numeric(0), y = numeric(0), `_source_key` = character(0),
+                        stringsAsFactors = FALSE, check.names = FALSE)
+    colnames(empty)[1:2] <- c(mapping$x_var, mapping$y_var)
+    return(list(data = empty, meta = new_transform_meta("loess",
+      list(sourceKeys = list(), derivedFrom = "input_rows"))))
+  }
+
+  span <- options$span %||% 0.75
+  degree <- options$degree %||% 2L
+  n_grid <- options$n_grid %||% 100L
+
+  model <- stats::loess(y_clean ~ x_clean, span = span, degree = degree)
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+  fitted_y <- stats::predict(model, newdata = data.frame(x_clean = grid_x))
+
+  transformed <- data.frame(
+    x = grid_x, y = fitted_y,
+    `_source_key` = sprintf("grid_%d", seq_len(n_grid)),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("loess", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_loess.R`:
+- "returns smoothed fitted values"
+- "respects span option"
+- "smaller span produces more wiggly fit"
+- "warns and returns empty with < 4 points"
+- "handles NA values in input"
+
+### 2b. `transform_polynomial` — Polynomial regression
+
+**Create** `R/transform_polynomial.R`:
+
+```r
+transform_polynomial <- function(data, mapping, options = list()) {
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  degree <- options$degree %||% 2L
+  n_grid <- options$n_grid %||% 100L
+
+  if (length(x_clean) <= degree) {
+    warning("transform_polynomial requires more data points than degree; returning empty.", call. = FALSE)
+    empty <- data.frame(x = numeric(0), y = numeric(0), `_source_key` = character(0),
+                        stringsAsFactors = FALSE, check.names = FALSE)
+    colnames(empty)[1:2] <- c(mapping$x_var, mapping$y_var)
+    return(list(data = empty, meta = new_transform_meta("polynomial",
+      list(sourceKeys = list(), derivedFrom = "input_rows"))))
+  }
+
+  model <- stats::lm(y_clean ~ stats::poly(x_clean, degree = degree, raw = TRUE))
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+  fitted_y <- stats::predict(model, newdata = data.frame(x_clean = grid_x))
+
+  transformed <- data.frame(
+    x = grid_x, y = fitted_y,
+    `_source_key` = sprintf("grid_%d", seq_len(n_grid)),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("polynomial", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_polynomial.R`:
+- "degree 2 fits quadratic data better than lm"
+- "warns and returns empty when degree >= n"
+- "respects n_grid option"
+- "passes through _source_key metadata"
+
+### 2c. `transform_smooth` — SMA + EMA
+
+**Create** `R/transform_smooth.R`:
+
+```r
+transform_smooth <- function(data, mapping, options = list()) {
+  method <- options$method %||% "sma"
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+
+  # Sort by x
+  ord <- order(x_vals)
+  x_sorted <- x_vals[ord]
+  y_sorted <- y_vals[ord]
+  keys_sorted <- as.character(data[["_source_key"]][ord])
+
+  if (method == "sma") {
+    window <- options$window %||% 7L
+    if (window > length(y_sorted)) {
+      warning("transform_smooth window (", window, ") exceeds data length (",
+              length(y_sorted), "); clamping.", call. = FALSE)
+      window <- length(y_sorted)
+    }
+    smoothed <- stats::filter(y_sorted, rep(1 / window, window), sides = 2)
+    keep <- !is.na(smoothed)
+    transformed <- data.frame(
+      x = x_sorted[keep], y = as.numeric(smoothed[keep]),
+      `_source_key` = keys_sorted[keep],
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else if (method == "ema") {
+    alpha <- options$alpha %||% 0.3
+    ema <- numeric(length(y_sorted))
+    ema[1] <- y_sorted[1]
+    for (i in seq(2, length(y_sorted))) {
+      ema[i] <- alpha * y_sorted[i] + (1 - alpha) * ema[i - 1]
+    }
+    transformed <- data.frame(
+      x = x_sorted, y = ema,
+      `_source_key` = keys_sorted,
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else {
+    stop("Unknown smooth method '", method, "'. Must be 'sma' or 'ema'.", call. = FALSE)
+  }
+
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("smooth", list(
+      sourceKeys = as.list(transformed[["_source_key"]]),
+      derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_smooth.R`:
+- "SMA with window=3 averages correctly"
+- "EMA with alpha=1 returns raw data"
+- "EMA with alpha=0 returns constant (first value)"
+- "SMA warns and clamps when window > nrow"
+- "unknown method errors"
+- "data is sorted by x before smoothing"
+
+### 2d. `transform_residuals` — Regression diagnostics
+
+**Create** `R/transform_residuals.R`:
+
+```r
+transform_residuals <- function(data, mapping, options = list()) {
+  method <- options$method %||% "lm"
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  model <- switch(method,
+    lm = stats::lm(y_clean ~ x_clean),
+    loess = stats::loess(y_clean ~ x_clean, span = options$span %||% 0.75),
+    polynomial = stats::lm(y_clean ~ stats::poly(x_clean, degree = options$degree %||% 2L, raw = TRUE)),
+    stop("Unknown residuals method '", method, "'.", call. = FALSE)
+  )
+
+  resid_vals <- stats::residuals(model)
+  fitted_vals <- stats::fitted(model)
+
+  transformed <- data.frame(
+    x = fitted_vals, y = resid_vals,
+    `_source_key` = as.character(data[["_source_key"]][complete]),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("residuals", list(
+      sourceKeys = as.list(transformed[["_source_key"]]),
+      derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_residuals.R`:
+- "lm residuals sum to approximately zero"
+- "residuals have same length as complete cases"
+- "loess method works"
+- "polynomial method works"
+- "x values are fitted values (not original x)"
+
+### 2e. Update registry and validation
+
+**Edit** `R/transform_registry.R` — add `loess`, `polynomial`, `smooth`, `residuals`.
+
+**Edit** `R/util.R`:
+- `VALID_COMBINATIONS$line`: add `"loess"`, `"polynomial"`, `"smooth"`
+- `VALID_COMBINATIONS$point`: add `"residuals"`
+
+### 2f. Verification
+
+```
+devtools::test()
+R CMD check --no-manual
+```
+
+Manual test: build bundle, create scatter + LOESS line in Shiny app, visually confirm smooth curve.
+
+---
+
+## Phase 3: CI and mean_ci transforms + validation fix (BLOCKER resolution)
+
+Gate: `devtools::test()` passes. CI band renders visually over scatter + trend line.
+
+### 3a. Validation refactor (BLOCKER B1+B2)
+
+**Edit** `R/addIoLayer.R`:
+
+Add a `TRANSFORM_INPUT_CONTRACTS` map after line 30 that defines what the *user* must provide (vs. what the transform produces):
+
+```r
+TRANSFORM_INPUT_CONTRACTS <- list(
+  ci = list(
+    required_map = c("x_var", "y_var"),
+    skip_column_check = c("low_y", "high_y"),
+    auto_mapping = list(low_y = "low_y", high_y = "high_y")
+  ),
+  mean_ci = list(
+    required_map = c("x_var", "y_var"),
+    skip_column_check = c("low_y", "high_y"),
+    auto_mapping = list(low_y = "low_y", high_y = "high_y")
+  )
+)
+```
+
+**Edit** `R/addIoLayer.R` `validate_layer_inputs` (line 175-228):
+
+After computing `required_map` at line 175-190, add:
+
+```r
+# Override required_map for transforms that change the output shape
+input_contract <- TRANSFORM_INPUT_CONTRACTS[[transform]]
+if (!is.null(input_contract)) {
+  required_map <- input_contract$required_map
+}
+```
+
+In the column-existence check (lines 196-201), skip fields listed in `skip_column_check`:
+
+```r
+skip_fields <- if (!is.null(input_contract)) input_contract$skip_column_check else character(0)
+mapped_fields <- setdiff(mapped_fields, skip_fields)
+```
+
+In the numeric check (lines 203-210), also skip `skip_column_check` fields.
+
+**Edit** `R/addIoLayer.R` — add auto-mapping injection after validation (after line 40, before transform execution):
+
+```r
+# Auto-inject transform output mapping (per Decision #11)
+input_contract <- TRANSFORM_INPUT_CONTRACTS[[transform]]
+if (!is.null(input_contract) && !is.null(input_contract$auto_mapping)) {
+  for (field in names(input_contract$auto_mapping)) {
+    if (is.null(mapping[[field]])) {
+      mapping[[field]] <- input_contract$auto_mapping[[field]]
+    }
+  }
+}
+```
+
+**Create** `tests/testthat/test_transform_input_contracts.R`:
+- "ci transform accepts x_var + y_var mapping (no low_y/high_y required)"
+- "mean_ci transform accepts x_var + y_var mapping"
+- "auto-injects low_y and high_y into mapping"
+- "user-provided low_y/high_y are not overwritten"
+- "validation still rejects missing x_var"
+
+### 3b. `transform_ci` — Confidence / Prediction interval
+
+**Create** `R/transform_ci.R`:
+
+```r
+transform_ci <- function(data, mapping, options = list()) {
+  method <- options$method %||% "lm"
+  level <- options$level %||% 0.95
+  interval <- options$interval %||% "confidence"
+  n_grid <- options$n_grid %||% 100L
+  x_vals <- data[[mapping$x_var]]
+  y_vals <- data[[mapping$y_var]]
+  complete <- !is.na(x_vals) & !is.na(y_vals)
+  x_clean <- x_vals[complete]
+  y_clean <- y_vals[complete]
+
+  if (length(x_clean) < 3L) {
+    warning("transform_ci requires at least 3 data points; returning empty.", call. = FALSE)
+    empty <- data.frame(x = numeric(0), low_y = numeric(0), high_y = numeric(0),
+                        stringsAsFactors = FALSE, check.names = FALSE)
+    colnames(empty)[1] <- mapping$x_var
+    return(list(data = empty, meta = new_transform_meta("ci",
+      list(sourceKeys = list(), derivedFrom = "input_rows"))))
+  }
+
+  grid_x <- seq(min(x_clean), max(x_clean), length.out = n_grid)
+
+  if (method == "lm") {
+    model <- stats::lm(y_clean ~ x_clean)
+    preds <- stats::predict(model,
+      newdata = data.frame(x_clean = grid_x),
+      interval = interval, level = level)
+    transformed <- data.frame(
+      x = grid_x, low_y = preds[, "lwr"], high_y = preds[, "upr"],
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else if (method == "loess") {
+    span <- options$span %||% 0.75
+    model <- stats::loess(y_clean ~ x_clean, span = span)
+    preds <- stats::predict(model,
+      newdata = data.frame(x_clean = grid_x), se = TRUE)
+    alpha <- 1 - level
+    df <- model$enp - 1
+    t_crit <- stats::qt(1 - alpha / 2, df = max(df, 1))
+    transformed <- data.frame(
+      x = grid_x,
+      low_y = preds$fit - t_crit * preds$se.fit,
+      high_y = preds$fit + t_crit * preds$se.fit,
+      stringsAsFactors = FALSE, check.names = FALSE
+    )
+  } else {
+    stop("Unknown ci method '", method, "'. Must be 'lm' or 'loess'.", call. = FALSE)
+  }
+
+  colnames(transformed)[1] <- mapping$x_var
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("ci", list(
+      sourceKeys = as.list(as.character(data[["_source_key"]][complete])),
+      derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_ci.R`:
+- "returns low_y and high_y columns"
+- "CI contains fitted line at every grid point"
+- "level=0.99 produces wider band than level=0.95"
+- "prediction interval is wider than confidence interval"
+- "loess method produces smooth bounds"
+- "warns and returns empty with < 3 points"
+- "respects n_grid option"
+
+### 3c. `transform_mean_ci` — Group mean ± CI
+
+**Create** `R/transform_mean_ci.R`:
+
+```r
+transform_mean_ci <- function(data, mapping, options = list()) {
+  level <- options$level %||% 0.95
+  method <- options$method %||% "t"
+  x_values <- data[[mapping$x_var]]
+  y_values <- data[[mapping$y_var]]
+  groups <- unique(x_values)
+
+  summarize_group <- function(gv) {
+    group_y <- y_values[x_values == gv]
+    group_y <- group_y[!is.na(group_y)]
+    n <- length(group_y)
+
+    if (n < 2L) {
+      return(data.frame(x = gv, y = if (n == 1L) group_y else NA_real_,
+        low_y = NA_real_, high_y = NA_real_, n = n, se = NA_real_,
+        stringsAsFactors = FALSE, check.names = FALSE))
+    }
+
+    m <- mean(group_y)
+    se <- stats::sd(group_y) / sqrt(n)
+    margin <- if (method == "t") {
+      stats::qt(1 - (1 - level) / 2, df = n - 1) * se
+    } else {
+      stats::qnorm(1 - (1 - level) / 2) * se
+    }
+
+    data.frame(x = gv, y = m, low_y = m - margin, high_y = m + margin,
+               n = n, se = se,
+               stringsAsFactors = FALSE, check.names = FALSE)
+  }
+
+  transformed <- do.call(rbind, lapply(groups, summarize_group))
+  colnames(transformed)[1:2] <- c(mapping$x_var, mapping$y_var)
+
+  source_keys <- lapply(groups, function(gv) {
+    as.character(data[["_source_key"]][x_values == gv])
+  })
+
+  list(
+    data = transformed,
+    meta = new_transform_meta("mean_ci", list(
+      sourceKeys = source_keys, derivedFrom = "input_rows"
+    ))
+  )
+}
+```
+
+**Create** `tests/testthat/test_transform_mean_ci.R`:
+- "bounds contain the mean"
+- "level=0.99 is wider than level=0.95"
+- "n=1 returns NA bounds"
+- "t-method matches stats::t.test output"
+- "se-method uses normal approximation"
+- "includes n and se columns"
+
+### 3d. Update registry and validation
+
+**Edit** `R/transform_registry.R` — add `ci`, `mean_ci`.
+
+**Edit** `R/util.R`:
+- `VALID_COMBINATIONS$area`: add `"ci"`
+- `VALID_COMBINATIONS$rangeBar`: add `"mean_ci"`
+
+### 3e. Verification
+
+```
+devtools::test()
+R CMD check --no-manual
+npm run build
+devtools::install()
+```
+
+Manual test: scatter + lm line + CI band area in Shiny app.
+
+---
+
+## Phase 4: JS changes + composite (BLOCKER B3 + W9 resolution)
+
+Gate: `npm run test` passes. TextRenderer renders R². LineRenderer suppresses points on fitted curves. CI band renders without scale issues.
+
+### 4a. Fix `processScales` to filter non-axes layers (BLOCKER B3)
+
+**Edit** `inst/htmlwidgets/myIO/src/derive/scales.js`:
+
+In `processScales`, before iterating layers, filter out layers whose renderer has `hasAxes: false`:
+
+```js
+// At the top of processScales, after receiving lys:
+var axesLayers = lys.filter(function(layer) {
+  var reg = registry.get(layer.type);
+  return !reg || reg.constructor.traits.hasAxes !== false;
+});
+// Use axesLayers instead of lys for extent computation
+```
+
+**Edit** `tests/js/scale-semantics.test.js`:
+- "layers with hasAxes: false are excluded from extent computation"
+
+### 4b. Fix LineRenderer point suppression (WARNING W9)
+
+**Edit** `inst/htmlwidgets/myIO/src/renderers/LineRenderer.js` line 52:
+
+```js
+// Before:
+if (layer.transform !== "lm") {
+
+// After:
+var fittingTransforms = ["lm", "loess", "polynomial", "smooth"];
+if (fittingTransforms.indexOf(layer.transform) === -1) {
+```
+
+**Edit** `tests/js/renderers.test.js`:
+- "LineRenderer suppresses points for loess transform"
+- "LineRenderer suppresses points for polynomial transform"
+- "LineRenderer suppresses points for smooth transform"
+
+### 4c. Create TextRenderer
+
+**Create** `inst/htmlwidgets/myIO/src/renderers/TextRenderer.js`:
+
+```js
+import { tagName } from "../utils/responsive.js";
+
+export class TextRenderer {
+  static type = "text";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "none",
+    binning: false,
+    rolloverStyle: "none",
+    scaleCapabilities: { invertX: false }
+  };
+  static scaleHints = {
+    xScaleType: "linear",
+    yScaleType: "linear",
+    xExtentFields: [],
+    yExtentFields: [],
+    domainMerge: "union"
+  };
+  static dataContract = {};
+
+  render(chart, layer) {
+    var position = (layer.options && layer.options.position) || "top-right";
+    var text = layer.data.map(function(d) { return d.text; }).join("\n");
+    var key = layer.label;
+    var className = tagName("text-annotation", chart.element.id, key);
+
+    // Remove existing
+    chart.chart.selectAll("." + className).remove();
+
+    var margins = { "top-right": { x: -10, y: 10, anchor: "end" },
+                    "top-left": { x: 10, y: 10, anchor: "start" },
+                    "bottom-right": { x: -10, y: -10, anchor: "end" },
+                    "bottom-left": { x: 10, y: -10, anchor: "start" } };
+    var m = margins[position] || margins["top-right"];
+    var isTop = position.indexOf("top") !== -1;
+    var isRight = position.indexOf("right") !== -1;
+
+    var x = isRight ? chart.width : 0;
+    var y = isTop ? 0 : chart.height;
+
+    var g = chart.chart.append("g")
+      .attr("class", className)
+      .attr("transform", "translate(" + (x + m.x) + "," + (y + m.y) + ")");
+
+    var lines = text.split("\n");
+    lines.forEach(function(line, i) {
+      g.append("text")
+        .attr("y", (isTop ? 1 : -1) * i * 16)
+        .attr("text-anchor", m.anchor)
+        .style("font-size", "12px")
+        .style("font-family", "var(--font-family, sans-serif)")
+        .style("fill", "var(--text-color, #333)")
+        .style("opacity", 0.8)
+        .text(line);
+    });
+  }
+
+  formatTooltip() { return null; }
+
+  remove(chart, layer) {
+    var className = tagName("text-annotation", chart.dom.element.id, layer.label);
+    chart.dom.chartArea.selectAll("." + className).remove();
+  }
+}
+```
+
+### 4d. Register TextRenderer
+
+**Edit** `inst/htmlwidgets/myIO/src/registry.js`:
+
+Add import and registration call in `registerBuiltInRenderers()`:
+
+```js
+import { TextRenderer } from "./renderers/TextRenderer.js";
+// ... in registerBuiltInRenderers():
+registerRenderer(new TextRenderer());
+```
+
+### 4e. JS tests
+
+**Edit** `tests/js/renderers.test.js`:
+- "TextRenderer registers with type 'text'"
+- "TextRenderer has hasAxes: false"
+- "TextRenderer has empty extent fields"
+
+**Edit** `tests/js/scale-semantics.test.js`:
+- "text layer does not affect scale domain"
+
+### 4f. `composite_regression`
+
+**Create** `R/composite_regression.R`:
+
+```r
+composite_regression <- function(data, mapping, label, color, options) {
+  method <- options$method %||% "lm"
+  show_ci <- if (is.null(options$showCI)) TRUE else isTRUE(options$showCI)
+  show_stats <- if (is.null(options$showStats)) TRUE else isTRUE(options$showStats)
+  level <- options$level %||% 0.95
+  interval <- options$interval %||% "confidence"
+
+  # Determine groups
+  if (!is.null(mapping$group) && mapping$group %in% colnames(data)) {
+    group_vals <- unique(data[[mapping$group]])
+  } else {
+    group_vals <- list(NULL)  # single group
+  }
+
+  sublayers <- list()
+
+  for (gv in group_vals) {
+    if (!is.null(gv)) {
+      group_data <- data[data[[mapping$group]] == gv, , drop = FALSE]
+      group_label <- paste0(label, " \u2014 ", as.character(gv))
+    } else {
+      group_data <- data
+      group_label <- label
+    }
+
+    # 1. Scatter points
+    sublayers[[length(sublayers) + 1L]] <- list(
+      type = "point", role = "scatter",
+      label = paste0(group_label, " (data)"),
+      data = group_data, mapping = mapping, transform = "identity",
+      color = color, options = list()
+    )
+
+    # 2. Trend line
+    sublayers[[length(sublayers) + 1L]] <- list(
+      type = "line", role = "trend",
+      label = paste0(group_label, " (trend)"),
+      data = group_data, mapping = mapping, transform = method,
+      color = color, options = options
+    )
+
+    # 3. CI band
+    if (show_ci) {
+      sublayers[[length(sublayers) + 1L]] <- list(
+        type = "area", role = "ci_band",
+        label = paste0(group_label, " (CI)"),
+        data = group_data,
+        mapping = list(x_var = mapping$x_var, y_var = mapping$y_var,
+                       low_y = "low_y", high_y = "high_y"),
+        transform = "ci",
+        color = color,
+        options = list(method = method, level = level, interval = interval,
+                       span = options$span, degree = options$degree)
+      )
+    }
+
+    # 4. R² annotation (only for lm/polynomial, first group only)
+    if (show_stats && length(sublayers) <= 4 && method %in% c("lm", "polynomial")) {
+      x_vals <- group_data[[mapping$x_var]]
+      y_vals <- group_data[[mapping$y_var]]
+      complete <- !is.na(x_vals) & !is.na(y_vals)
+      if (sum(complete) >= 3L) {
+        model <- if (method == "lm") {
+          stats::lm(y_vals[complete] ~ x_vals[complete])
+        } else {
+          stats::lm(y_vals[complete] ~ stats::poly(x_vals[complete],
+            degree = options$degree %||% 2L, raw = TRUE))
+        }
+        r_sq <- summary(model)$r.squared
+        coefs <- stats::coef(model)
+        eq_text <- if (method == "lm") {
+          sprintf("y = %s x + %s", format(round(coefs[2], 3), nsmall = 3),
+                  format(round(coefs[1], 3), nsmall = 3))
+        } else {
+          paste0("poly(", options$degree %||% 2L, ")")
+        }
+
+        annotation_data <- data.frame(
+          text = c(
+            paste0("R\u00B2 = ", format(round(r_sq, 3), nsmall = 3)),
+            eq_text
+          ),
+          stringsAsFactors = FALSE
+        )
+
+        sublayers[[length(sublayers) + 1L]] <- list(
+          type = "text", role = "annotation",
+          label = paste0(group_label, " (stats)"),
+          data = annotation_data, mapping = list(),
+          transform = "identity", color = NULL,
+          options = list(position = "top-right")
+        )
+      }
+    }
+  }
+
+  sublayers
+}
+```
+
+### 4g. Update registries
+
+**Edit** `R/util.R`:
+- Add `"text"` and `"regression"` to `ALLOWED_TYPES`
+- Add `regression = composite_regression` to `composite_registry()`
+- Add `text = "axes-continuous"` and `regression = "axes-continuous"` to `COMPATIBILITY_GROUPS`
+- Add `text = c("identity")` to `VALID_COMBINATIONS`
+
+### 4h. Composite tests
+
+**Create** `tests/testthat/test_composite_regression.R`:
+- "creates 3 sublayers by default (scatter, trend, CI)"
+- "creates 4 sublayers with showStats=TRUE"
+- "showCI=FALSE produces 2 sublayers"
+- "trend sublayer uses specified method"
+- "CI sublayer is type area with ci transform"
+- "grouped data produces N sets of sublayers"
+- "annotation sublayer contains R² text"
+
+### 4i. Build and verify
+
+```
+npm run build
+npm run test
+devtools::install()
+devtools::test()
+R CMD check --no-manual
+```
+
+---
+
+## Phase 5: E2E integration tests + gallery
+
+Gate: Full test suite passes. All new chart types render in gallery app.
+
+### 5a. E2E widget tests
+
+**Edit** `tests/testthat/test_e2e_widgets.R` — add test cases:
+
+```r
+test_that("regression composite renders", {
+  w <- myIO(data = mtcars) |>
+    addIoLayer(type = "regression", label = "mpg vs wt",
+      mapping = list(x_var = "wt", y_var = "mpg"))
+  html <- htmlwidgets::saveWidget(w, tempfile(fileext = ".html"))
+  expect_true(file.exists(html))
+})
+
+test_that("scatter + lm + CI band renders", {
+  w <- myIO(data = mtcars) |>
+    addIoLayer(type = "point", label = "data",
+      mapping = list(x_var = "wt", y_var = "mpg")) |>
+    addIoLayer(type = "line", label = "trend", transform = "lm",
+      mapping = list(x_var = "wt", y_var = "mpg")) |>
+    addIoLayer(type = "area", label = "CI", transform = "ci",
+      mapping = list(x_var = "wt", y_var = "mpg"))
+  expect_equal(length(w$x$config$layers), 3L)
+})
+
+test_that("LOESS line renders", { ... })
+test_that("mean_ci error bars render", { ... })
+test_that("SMA overlay renders", { ... })
+test_that("residual plot renders", { ... })
+```
+
+### 5b. Gallery app updates
+
+**Edit** the Shiny gallery app to add a "Statistical" tab showcasing:
+- Regression composite (scatter + trend + CI + R²)
+- Mean ± CI error bars (iris species)
+- LOESS smoothing
+- Moving average overlay
+- Residual diagnostic plot
+
+### 5c. Final verification
+
+```
+npm run build
+npm run test
+devtools::install()
+devtools::test()
+R CMD check --no-manual
+```
+
+---
+
+## File Inventory
+
+### New files (14)
+
+| File | Phase | Description |
+|------|-------|-------------|
+| `R/transform_mean.R` | 1 | Group mean |
+| `R/transform_summary.R` | 1 | General aggregation |
+| `R/transform_loess.R` | 2 | LOESS smoothing |
+| `R/transform_polynomial.R` | 2 | Polynomial regression |
+| `R/transform_smooth.R` | 2 | SMA + EMA |
+| `R/transform_residuals.R` | 2 | Regression residuals |
+| `R/transform_ci.R` | 3 | Confidence/prediction intervals |
+| `R/transform_mean_ci.R` | 3 | Group mean ± CI |
+| `R/composite_regression.R` | 4 | Regression composite |
+| `inst/htmlwidgets/myIO/src/renderers/TextRenderer.js` | 4 | Text annotation renderer |
+| `tests/testthat/test_transform_mean.R` | 1 | |
+| `tests/testthat/test_transform_summary.R` | 1 | |
+| `tests/testthat/test_transform_loess.R` | 2 | |
+| `tests/testthat/test_transform_polynomial.R` | 2 | |
+| `tests/testthat/test_transform_smooth.R` | 2 | |
+| `tests/testthat/test_transform_residuals.R` | 2 | |
+| `tests/testthat/test_transform_ci.R` | 3 | |
+| `tests/testthat/test_transform_mean_ci.R` | 3 | |
+| `tests/testthat/test_transform_input_contracts.R` | 3 | |
+| `tests/testthat/test_composite_regression.R` | 4 | |
+
+### Edited files (7)
+
+| File | Phase | Change |
+|------|-------|--------|
+| `R/transform_registry.R` | 1-3 | Add 8 new entries |
+| `R/util.R` | 1-4 | Update ALLOWED_TYPES, VALID_COMBINATIONS, COMPATIBILITY_GROUPS, composite_registry |
+| `R/addIoLayer.R` | 3 | Add TRANSFORM_INPUT_CONTRACTS, auto-mapping injection, validation bypass |
+| `inst/htmlwidgets/myIO/src/renderers/LineRenderer.js` | 4 | Expand point-suppression list |
+| `inst/htmlwidgets/myIO/src/derive/scales.js` | 4 | Filter non-axes layers from extent computation |
+| `inst/htmlwidgets/myIO/src/registry.js` | 4 | Import + register TextRenderer |
+| `tests/testthat/test_e2e_widgets.R` | 5 | Add statistical chart E2E tests |
+
+### No deleted files
+
+---
+
+## Dependency Order (DAG)
+
+```
+Phase 1 ─────────────────────────────────────────────────┐
+  transform_mean, transform_summary                      │
+  registry + VALID_COMBINATIONS updates                   │
+                                                          │
+Phase 2 ──────────── (depends on Phase 1 registry)  ─────┤
+  transform_loess, transform_polynomial                   │
+  transform_smooth, transform_residuals                   │
+  registry + VALID_COMBINATIONS updates                   │
+                                                          │
+Phase 3 ──────────── (depends on Phase 2)  ──────────────┤
+  TRANSFORM_INPUT_CONTRACTS + validation refactor         │
+  transform_ci (needs validation fix first)               │
+  transform_mean_ci (needs validation fix first)          │
+  registry + VALID_COMBINATIONS updates                   │
+                                                          │
+Phase 4 ──────────── (depends on Phase 3)  ──────────────┤
+  scales.js fix (BLOCKER B3)                              │
+  LineRenderer fix (W9)                                   │
+  TextRenderer.js + registry.js                           │
+  composite_regression (needs ci, text, all transforms)   │
+  util.R final updates                                    │
+                                                          │
+Phase 5 ──────────── (depends on Phase 4)  ──────────────┘
+  E2E tests
+  Gallery app updates
+```
+
+Each phase is independently shippable and verifiable. Phases 1 and 2 deliver value (new transforms) without touching existing JS or validation logic. Phase 3 is the riskiest (validation refactor) and should be reviewed carefully. Phase 4 completes the JS + composite story. Phase 5 is polish.
+
+---
+
+## Dependencies
+
+**No new R package dependencies.** All computation uses `stats::lm`, `stats::loess`, `stats::predict`, `stats::qt`, `stats::qnorm`, `stats::sd`, `stats::poly`, `stats::filter`, `stats::residuals`, `stats::fitted`. All are in base R `stats` package (already in Imports).
+
+**No new JS dependencies.** TextRenderer uses D3 selections already available. No npm additions.

--- a/md/strategy/market/statistics-augmentation.md
+++ b/md/strategy/market/statistics-augmentation.md
@@ -1,0 +1,174 @@
+# Market Research: Statistics Augmentation for Interactive R Visualization
+## Date: 2026-03-21
+
+## Executive summary
+
+Interactive statistical visualization in R is a growing market (~200K-500K active users) with a clear vacuum opening: Plotly is deprioritizing R (retiring docs, 753 open issues, declining maintenance), and no existing package provides native, first-class statistical overlays (CI bands, regression diagnostics, distribution fits) on interactive D3-powered charts. The #1 validated user complaint — broken confidence interval rendering in ggplotly — has been open for 7+ years with zero response. myIO's transform pipeline is architecturally ready to fill this gap. Statistics augmentation isn't optional polish — it's the CRAN differentiation story.
+
+## Market size
+
+| Metric | Estimate | Source | Confidence |
+|--------|----------|--------|------------|
+| TAM | 2-3M R users worldwide | Stack Overflow Survey 2025 (4.9% of devs), TIOBE #10 | Medium |
+| SAM | 200K-500K interactive viz users | htmlwidgets 8.2M downloads/yr, Shiny 6.3M/yr | Medium |
+| SOM | 10K-30K users (3-year target) | Plotly R users seeking alternatives post-doc-retirement | Low |
+
+## Growth and trends
+
+- **R is growing, not dying.** Stack Overflow share rose from 4.3% (2024) to 4.9% (2025). TIOBE climbed to #10. R specializing in stats/bioinformatics/regulatory niches.
+- **Interactive viz adoption accelerating.** htmlwidgets downloads grew 66% (4.96M → 8.23M) from 2022-2025. ggiraph nearly tripled.
+- **Plotly R is in decline.** Documentation retired Nov 2025. Dash R/Julia/Matlab/F# docs already gone. Release cadence down to ~1/year. 753 open issues. Community asking "should I remove plotly as a dependency?"
+- **Shiny enterprise adoption strong.** ~6.3M downloads/yr, active conference circuit (ShinyConf, Shiny in Production), pharma/finance verticals driving demand.
+- **Growth rate**: Interactive R viz ~20% CAGR (htmlwidgets download trend). Shiny stable at ~6M/yr.
+
+## Buyer segments
+
+| Segment | Size | Pain intensity | Willingness to pay | Our fit |
+|---------|------|---------------|-------------------|---------|
+| Academic researchers (biostat, epi, social science) | Large (~40% of R users) | High — need CI bands, p-values, regression diagnostics on interactive plots | Low (open-source expectation) | Strong — transform pipeline maps directly to their workflow |
+| Pharma/life sciences (FDA submissions, clinical trials) | Medium | High — regulatory viz needs are precise, interactive reporting growing | High (enterprise budgets) | Strong — distribution fits, CI bands, survival curves |
+| Professional Shiny developers (consultancies, internal tools) | Medium (~50K) | Medium-High — frustrated with ggplotly conversion bugs | Medium (billable hours saved) | Strong — native Shiny integration, no ggplotly translation layer |
+| Data journalists / communicators | Small | Low — need simple interactive charts, not statistical overlays | Low | Weak — not our primary value prop |
+| Finance / quantitative analysts | Medium | Medium — need time-series smoothing, candlestick + moving averages | Medium | Moderate — candlestick exists, smoothing transforms would add value |
+
+## Competitive landscape
+
+| Player | Position | Strength | Weakness | Threat level |
+|--------|----------|----------|----------|-------------|
+| **plotly (R)** | Dominant incumbent, declining | 40+ chart types, ggplotly() one-liner, name recognition | Retiring R docs, 753 open issues, CI bands broken 7+ years, ggplotly conversion fundamentally flawed | Low (declining) |
+| **ggiraph** | Rising ggplot2 extension | Inherits ALL ggplot2 stat layers, faithful rendering, linked brushing | SVG-only (perf degrades >10K points), no independent statistical compute | Medium (different niche) |
+| **echarts4r** | Full-featured alternative | e_lm(), e_band(), e_band2() for stats, Apache 2.0 license, good defaults | Small community (84K downloads/yr), non-ggplot2 API, limited docs | Medium (closest competitor on stats) |
+| **highcharter** | Premium option | Beautiful defaults, extensive chart types, drilldown | Commercial license ($590+/yr), no native stat features, must compute externally | Low (license barrier) |
+| **apexcharter** | Lightweight dashboard tool | Clean API, MIT license | No statistical features, tiny user base (20K/yr) | Low |
+| **r2d3** | Raw D3 bridge | Full D3 power | Requires JavaScript programming, minimal maintenance, no abstractions | Low (different market) |
+
+### Statistical overlay support (validated)
+
+| Feature | plotly | ggiraph | echarts4r | highcharter | apexcharter | **myIO opportunity** |
+|---------|--------|---------|-----------|-------------|-------------|---------------------|
+| CI bands | Broken in ggplotly (7yr bug) | Via ggplot2 stat layers | e_band() / e_band2() | Manual computation | No | **Native, first-class** |
+| Error bars | Yes | Via ggplot2 | Yes | Yes | No | Native |
+| Regression lines | Via ggplotly (buggy) | Via ggplot2 | e_lm() (basic) | Manual | No | **Native + CI** |
+| Regression equation / R² | Broken in ggplotly (#1687) | Via ggplot2 extensions | No | No | No | **Differentiator** |
+| Distribution fitting | No | Via ggplot2 stat | No | No | No | **Differentiator** |
+| Statistical test annotations | No | No | No | No | No | **Differentiator** |
+| LOESS / non-linear smooth | Via ggplotly (conversion issues) | Via ggplot2 | No | No | No | **Differentiator** |
+
+### Market structure
+
+**Fragmenting.** Plotly held dominant position but is ceding the R market. No clear successor. ggiraph is growing fastest but stays within ggplot2's paradigm (static-first, interactivity bolted on). echarts4r has the closest statistical features but small community. **This is an ideal entry window for a focused competitor.**
+
+## Timing analysis
+
+- **Why now**: Plotly retired R docs (Nov 2025). Dash R/Julia/Matlab docs already gone. Professional Shiny developers are actively asking "what do I migrate to?" (GitHub issue #2456, Posit Community thread). The window is open NOW.
+- **Why not sooner**: Before Nov 2025, plotly was "good enough" despite bugs. The doc retirement was the trigger that made the community acknowledge the problem.
+- **Window**: 12-18 months. Once the community settles on a successor (ggiraph for ggplot2 users, echarts4r for JS-native), switching costs rise. First mover with credible statistical features wins the "plotly replacement for Shiny" narrative.
+
+## Validated user complaints (real issues, real URLs)
+
+### The Big One: CI Bands Broken for 7+ Years
+
+- **[plotly/plotly.R #1472](https://github.com/plotly/plotly.R/issues/1472)** (2019, STILL OPEN, 0 comments): geom_smooth CI ribbon renders nonsensical extra band below fitted line. Zero maintainer response in 7 years.
+- **[plotly/plotly.R #1060](https://github.com/plotly/plotly.R/issues/1060)** (2017, STILL OPEN): geom_ribbon() breaks with NA values. Open 9 years.
+- **[Plotly Community Forum](https://community.plotly.com/t/bug-strange-behavior-when-using-geom-ribbon-with-ggplotly-in-r/2003)**: Multiple threads confirming ribbon/CI rendering broken.
+
+### Regression Annotations Don't Work
+
+- **[plotly/plotly.R #1687](https://github.com/plotly/plotly.R/issues/1687)** (2020): stat_poly_eq (regression equation display) completely disappears in ggplotly. User: *"It is really urgent for me to show equation using ggplotly."*
+
+### Growing List of Unimplemented Statistical Geoms (2025 alone)
+
+- **#2428**: geom_GeomTextRepel not implemented
+- **#2425**: geom_GeomLabel not implemented
+- **#1705**: geom_GeomQqBand not implemented (QQ diagnostic bands)
+- **#1404**: geom_GeomConfint not implemented (survival curve CIs)
+
+### Performance Pain in Shiny
+
+- **[Plotly Community](https://community.plotly.com/t/major-performance-difference-between-ggplotly-and-plot-ly/650)**: ggplotly renders in ~1s but plot_ly takes 5+ seconds with large datasets.
+- **[#1874](https://github.com/plotly/plotly.R/issues/1874)**: partial_bundle() performance optimization itself is broken in Shiny.
+
+### The Existential Question
+
+- **[plotly/plotly.R #2456](https://github.com/plotly/plotly.R/issues/2456)** (Oct 2025): "Plotly is retiring its R documentation."
+  - Hadley Wickham: *"No concrete news from us, but we are discussing this internally."*
+  - Professional Shiny dev @Mkranj: *"We would appreciate new core Plotly.js functionality more than ggplotly() compatibility."*
+  - User @SpikyClip: *"Or is Plotly R going to be completely abandoned, and I should remove it as a dependency from all our projects?"*
+
+## Our opportunity
+
+- **Wedge**: Interactive CI bands and regression overlays that actually work — the #1 broken feature in plotly R. Lead with "confidence intervals that render correctly, out of the box."
+- **Differentiation**: Composable transform pipeline (compute → render separation). No ggplotly translation layer to break. Statistical computation in R (where it belongs), rendering in D3 (where it's beautiful). Only package offering native distribution fitting + test annotations on interactive charts.
+- **Build vs. partner**: Build. The transform pipeline architecture is purpose-built for this. Each new transform is 40-80 LOC following a proven pattern. No external dependencies needed beyond base R `stats`.
+
+## What to build (priority-ordered by validated demand)
+
+### Tier 1: Directly addresses top user complaints
+
+| Transform | What it solves | Validated by |
+|-----------|---------------|-------------|
+| `transform_lm` + CI bands | CI ribbon rendering (broken in plotly for 7 years) | Issues #1472, #1060, forum threads |
+| `transform_loess` | Non-linear smoothing (ggplotly conversion issues) | geom_smooth conversion bugs |
+| `transform_mean_ci` | Mean ± 95% CI error bars | Standard scientific practice; no interactive package does this natively |
+| Regression equation / R² annotation | Equation display (broken in plotly #1687) | Issue #1687, "really urgent" user quote |
+
+### Tier 2: Completes the statistical story
+
+| Transform | What it solves | Validated by |
+|-----------|---------------|-------------|
+| `transform_summary` (count/sum/sd) | Pre-aggregation burden | Common Stack Overflow pattern |
+| `transform_quantile_bands` | Percentile ribbons beyond boxplot 5-number summary | Time-series and longitudinal analysis needs |
+| `transform_smooth` (moving average) | Time-series smoothing | Finance/operational dashboard use cases |
+| `transform_polynomial` | Non-linear regression | Scientific modeling standard |
+
+### Tier 3: Advanced differentiation
+
+| Transform | What it solves | Validated by |
+|-----------|---------------|-------------|
+| `transform_fit_distribution` | Parametric distribution overlay | No competitor offers this |
+| `transform_residuals` | Regression diagnostics | QQ band issues (#1705) |
+| `composite_regression` | Scatter + line + CI + R² in one call | Workflow simplification |
+
+## Recommendation
+
+**Invest now.** This is the CRAN differentiation story AND the market timing is right:
+
+1. The #1 user pain point (broken CI bands) maps directly to our strongest architectural advantage (composable transforms)
+2. Plotly's R retreat creates a 12-18 month window before the community settles on alternatives
+3. No competitor offers native statistical overlays on interactive D3 charts
+4. Implementation cost is low — each transform is 40-80 LOC following a proven pattern
+5. This transforms the CRAN narrative from "another charting wrapper" to "interactive statistical visualization toolkit"
+
+**Sequence**: Tier 1 transforms first (CI bands, LOESS, mean±CI) → CRAN submission with differentiation story → Tier 2 post-acceptance → Tier 3 based on user feedback.
+
+## Open questions
+
+- Should transforms support grouped regression (separate model per group) from day one, or add it as a follow-up?
+- Text annotation renderer in JS — needed for R²/equation display. How complex is this to add to the existing renderer architecture?
+- Should we add a `composite_regression` (scatter + line + CI band) as a convenience composite, or let users compose layers manually?
+- Performance: LOESS on 100K+ rows may be slow before serialization. Test and potentially add sampling option.
+- echarts4r's `e_band()` is the closest competitor feature — should we study their API for ergonomic inspiration?
+
+## Sources
+
+- [Plotly retiring R documentation — GitHub #2456](https://github.com/plotly/plotly.R/issues/2456)
+- [Plotly retiring R documentation — Posit Community](https://forum.posit.co/t/plotly-is-retiring-its-r-documentation/208325)
+- [Plotly R development virtually stopped? — Plotly Community](https://community.plotly.com/t/plotly-r-development-virtually-stopped/88894)
+- [Retiring non-Python Dash docs — Plotly](https://community.plotly.com/t/retiring-the-non-python-dash-documentation/92122)
+- [geom_smooth CI bug #1472 (open since 2019)](https://github.com/plotly/plotly.R/issues/1472)
+- [geom_ribbon NA bug #1060 (open since 2017)](https://github.com/plotly/plotly.R/issues/1060)
+- [Regression equation bug #1687](https://github.com/plotly/plotly.R/issues/1687)
+- [geom_ribbon rendering bugs — Plotly Community](https://community.plotly.com/t/bug-strange-behavior-when-using-geom-ribbon-with-ggplotly-in-r/2003)
+- [Performance: ggplotly vs plot_ly — Plotly Community](https://community.plotly.com/t/major-performance-difference-between-ggplotly-and-plot-ly/650)
+- [partial_bundle broken in Shiny #1874](https://github.com/plotly/plotly.R/issues/1874)
+- [ggplotly regressions PR #2472](https://github.com/plotly/plotly.R/pull/2472)
+- [Improving ggplotly — official docs](https://plotly-r.com/improving-ggplotly.html)
+- [echarts4r statistical plots](https://echarts4r.john-coene.com/articles/stats.html)
+- [ggiraph — InfoWorld](https://www.infoworld.com/article/2268015/easy-interactive-ggplot-graphs-in-r-with-ggiraph.html)
+- [r2d3 — Posit](https://rstudio.github.io/r2d3/)
+- [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/technology)
+- [R climbs back to TIOBE top 10 — FlowingData](https://flowingdata.com/2025/12/19/r-climbs-back-up-into-the-top-ten-programming-languages)
+- [CRAN Task View: Dynamic Visualizations](https://cran.r-project.org/web/views/DynamicVisualizations.html)
+- [Interactive Data Visualization with R — Tidy Intelligence](https://blog.tidy-intelligence.com/posts/interactive-data-visualization-with-r/)
+- [CRAN Downloads API](https://cranlogs.r-pkg.org/)
+- [htmlwidgets cross-widget communication #86](https://github.com/ramnathv/htmlwidgets/issues/86)

--- a/tests/testthat/test_composite_regression.R
+++ b/tests/testthat/test_composite_regression.R
@@ -1,0 +1,110 @@
+test_that("composite_regression creates 3 sublayers by default (scatter, trend, CI)", {
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(showStats = FALSE)
+  )
+  expect_equal(length(sublayers), 3)
+  expect_equal(sublayers[[1]]$type, "point")
+  expect_equal(sublayers[[1]]$role, "scatter")
+  expect_equal(sublayers[[2]]$type, "line")
+  expect_equal(sublayers[[2]]$role, "trend")
+  expect_equal(sublayers[[3]]$type, "area")
+  expect_equal(sublayers[[3]]$role, "ci_band")
+})
+
+test_that("composite_regression creates 4 sublayers with showStats=TRUE", {
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(showStats = TRUE)
+  )
+  expect_equal(length(sublayers), 4)
+  expect_equal(sublayers[[4]]$type, "text")
+  expect_equal(sublayers[[4]]$role, "annotation")
+})
+
+test_that("showCI=FALSE produces 2 sublayers", {
+  df <- data.frame(
+    x = 1:20, y = 1:20,
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(showCI = FALSE, showStats = FALSE)
+  )
+  expect_equal(length(sublayers), 2)
+  expect_equal(sublayers[[1]]$type, "point")
+  expect_equal(sublayers[[2]]$type, "line")
+})
+
+test_that("trend sublayer uses specified method", {
+  df <- data.frame(
+    x = 1:20, y = (1:20)^2,
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(method = "loess", showStats = FALSE)
+  )
+  expect_equal(sublayers[[2]]$transform, "loess")
+})
+
+test_that("CI sublayer is type area with ci transform", {
+  df <- data.frame(
+    x = 1:20, y = 1:20,
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(showStats = FALSE)
+  )
+  ci_layer <- sublayers[[3]]
+  expect_equal(ci_layer$type, "area")
+  expect_equal(ci_layer$transform, "ci")
+  expect_equal(ci_layer$mapping$low_y, "low_y")
+  expect_equal(ci_layer$mapping$high_y, "high_y")
+})
+
+test_that("grouped data produces N sets of sublayers", {
+  df <- data.frame(
+    x = rep(1:10, 2),
+    y = c(1:10, 2 * (1:10)),
+    grp = rep(c("A", "B"), each = 10),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y", group = "grp"), "test", "#333",
+    options = list(showStats = FALSE)
+  )
+  # 2 groups × 3 sublayers (scatter, trend, CI) = 6
+  expect_equal(length(sublayers), 6)
+})
+
+test_that("annotation sublayer contains R-squared text", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 0.5),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  sublayers <- myIO:::composite_regression(
+    df, list(x_var = "x", y_var = "y"), "test", "#333",
+    options = list(showStats = TRUE)
+  )
+  annotation <- sublayers[[4]]
+  expect_true(grepl("R\u00B2", annotation$data$text[1]))
+  expect_true(grepl("y =", annotation$data$text[2]))
+})

--- a/tests/testthat/test_e2e_widgets.R
+++ b/tests/testthat/test_e2e_widgets.R
@@ -464,6 +464,95 @@ test_that("Theme demo renders with custom theme and reference line", {
   save_widget(w, "12_theme_demo")
 })
 
+# ---- Statistical augmentation E2E tests ----
+
+test_that("Regression composite renders with scatter + trend + CI + R²", {
+  set.seed(42)
+  df <- data.frame(x = 1:30, y = 2 * (1:30) + rnorm(30, sd = 3))
+  w <- myIO(data = df) |>
+    addIoLayer(type = "regression", label = "regression demo",
+      mapping = list(x_var = "x", y_var = "y"),
+      options = list(method = "lm", showCI = TRUE, showStats = TRUE))
+  layers <- w$x$config$layers
+  types <- sapply(layers, function(l) l$type)
+  expect_true("point" %in% types)
+  expect_true("line" %in% types)
+  expect_true("area" %in% types)
+  expect_true("text" %in% types)
+  save_widget(w, "13_regression_composite")
+})
+
+test_that("Scatter + lm line + CI band renders via manual composition", {
+  df <- data.frame(x = 1:25, y = 3 * (1:25) + rnorm(25, sd = 2))
+  w <- myIO(data = df) |>
+    addIoLayer(type = "point", label = "scatter",
+      mapping = list(x_var = "x", y_var = "y")) |>
+    addIoLayer(type = "line", label = "trend", transform = "lm",
+      mapping = list(x_var = "x", y_var = "y")) |>
+    addIoLayer(type = "area", label = "95% CI", transform = "ci",
+      mapping = list(x_var = "x", y_var = "y"))
+  expect_equal(length(w$x$config$layers), 3)
+  ci_layer <- w$x$config$layers[[3]]
+  expect_equal(ci_layer$transform, "ci")
+  expect_equal(ci_layer$mapping$low_y, "low_y")
+  save_widget(w, "14_scatter_lm_ci")
+})
+
+test_that("LOESS smoothing renders", {
+  set.seed(42)
+  df <- data.frame(x = 1:50, y = sin(seq(0, 4*pi, length.out = 50)) + rnorm(50, sd = 0.3))
+  w <- myIO(data = df) |>
+    addIoLayer(type = "point", label = "data",
+      mapping = list(x_var = "x", y_var = "y")) |>
+    addIoLayer(type = "line", label = "loess", transform = "loess",
+      mapping = list(x_var = "x", y_var = "y"),
+      options = list(span = 0.3))
+  expect_equal(length(w$x$config$layers), 2)
+  loess_layer <- w$x$config$layers[[2]]
+  expect_equal(length(loess_layer$data), 100)
+  save_widget(w, "15_loess_smoothing")
+})
+
+test_that("Mean ± CI error bars render", {
+  df <- data.frame(
+    species = rep(c("setosa", "versicolor", "virginica"), each = 20),
+    value = c(rnorm(20, 5, 0.5), rnorm(20, 6, 0.6), rnorm(20, 7, 0.7))
+  )
+  w <- myIO(data = df) |>
+    addIoLayer(type = "rangeBar", label = "mean CI", transform = "mean_ci",
+      mapping = list(x_var = "species", y_var = "value"),
+      options = list(level = 0.95))
+  layer <- w$x$config$layers[[1]]
+  expect_equal(layer$transform, "mean_ci")
+  expect_equal(length(layer$data), 3)
+  save_widget(w, "16_mean_ci_errorbars")
+})
+
+test_that("Moving average overlay renders", {
+  df <- data.frame(x = 1:100, y = cumsum(rnorm(100)))
+  w <- myIO(data = df) |>
+    addIoLayer(type = "line", label = "raw",
+      mapping = list(x_var = "x", y_var = "y")) |>
+    addIoLayer(type = "line", label = "SMA-10", transform = "smooth",
+      mapping = list(x_var = "x", y_var = "y"),
+      options = list(method = "sma", window = 10))
+  expect_equal(length(w$x$config$layers), 2)
+  save_widget(w, "17_moving_average")
+})
+
+test_that("Residual plot renders", {
+  set.seed(42)
+  df <- data.frame(x = 1:30, y = 2 * (1:30) + rnorm(30, sd = 3))
+  w <- myIO(data = df) |>
+    addIoLayer(type = "point", label = "residuals", transform = "residuals",
+      mapping = list(x_var = "x", y_var = "y")) |>
+    setReferenceLines(list(list(axis = "y", value = 0, label = "zero")))
+  layer <- w$x$config$layers[[1]]
+  expect_equal(layer$transform, "residuals")
+  expect_equal(length(layer$data), 30)
+  save_widget(w, "18_residual_plot")
+})
+
 # Print output directory for visual review
 cat("\n\n=== E2E HTML files saved to:", output_dir, "===\n")
 cat("Open these in a browser to visually verify each chart type.\n\n")

--- a/tests/testthat/test_transform_ci.R
+++ b/tests/testthat/test_transform_ci.R
@@ -1,0 +1,108 @@
+test_that("transform_ci returns low_y and high_y columns", {
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"))
+  expect_true("low_y" %in% colnames(result$data))
+  expect_true("high_y" %in% colnames(result$data))
+  expect_equal(nrow(result$data), 100)
+})
+
+test_that("CI contains fitted line at every grid point", {
+  df <- data.frame(
+    x = 1:30, y = 3 * (1:30) + 5 + rnorm(30, sd = 0.5),
+    `_source_key` = paste0("row_", 1:30),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  ci_result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"))
+  # Fit the same model and predict at grid points
+  x_clean <- df$x
+  y_clean <- df$y
+  model <- lm(y_clean ~ x_clean)
+  grid_x <- ci_result$data$x
+  fitted_vals <- predict(model, newdata = data.frame(x_clean = grid_x))
+  expect_true(all(ci_result$data$low_y <= fitted_vals + 1e-10))
+  expect_true(all(ci_result$data$high_y >= fitted_vals - 1e-10))
+})
+
+test_that("level=0.99 produces wider band than level=0.95", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:30, y = (1:30) + rnorm(30, sd = 2),
+    `_source_key` = paste0("row_", 1:30),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  ci_95 <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                                options = list(level = 0.95))
+  ci_99 <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                                options = list(level = 0.99))
+  width_95 <- mean(ci_95$data$high_y - ci_95$data$low_y)
+  width_99 <- mean(ci_99$data$high_y - ci_99$data$low_y)
+  expect_true(width_99 > width_95)
+})
+
+test_that("prediction interval is wider than confidence interval", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:30, y = (1:30) + rnorm(30, sd = 2),
+    `_source_key` = paste0("row_", 1:30),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  ci <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                             options = list(interval = "confidence"))
+  pi <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                             options = list(interval = "prediction"))
+  ci_width <- mean(ci$data$high_y - ci$data$low_y)
+  pi_width <- mean(pi$data$high_y - pi$data$low_y)
+  expect_true(pi_width > ci_width)
+})
+
+test_that("loess method produces smooth bounds", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:30, y = sin(1:30) + rnorm(30, sd = 0.2),
+    `_source_key` = paste0("row_", 1:30),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                                 options = list(method = "loess"))
+  expect_equal(nrow(result$data), 100)
+  expect_true(all(result$data$high_y >= result$data$low_y))
+})
+
+test_that("transform_ci warns and returns empty with < 3 points", {
+  df <- data.frame(
+    x = 1:2, y = c(1, 2),
+    `_source_key` = c("row_1", "row_2"),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_warning(
+    result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y")),
+    "at least 3"
+  )
+  expect_equal(nrow(result$data), 0)
+})
+
+test_that("transform_ci respects n_grid option", {
+  df <- data.frame(
+    x = 1:20, y = 1:20,
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"),
+                                 options = list(n_grid = 50))
+  expect_equal(nrow(result$data), 50)
+})
+
+test_that("transform_ci returns correct metadata", {
+  df <- data.frame(
+    x = 1:10, y = 1:10,
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_ci(df, list(x_var = "x", y_var = "y"))
+  expect_equal(result$meta$name, "ci")
+  expect_equal(result$meta$derivedFrom, "input_rows")
+})

--- a/tests/testthat/test_transform_input_contracts.R
+++ b/tests/testthat/test_transform_input_contracts.R
@@ -1,0 +1,61 @@
+test_that("ci transform accepts x_var + y_var mapping without low_y/high_y", {
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 1),
+    stringsAsFactors = FALSE
+  )
+  # Should not error — validation should accept x_var + y_var for ci transform
+  w <- myIO::myIO(data = df) |>
+    myIO::addIoLayer(
+      type = "area", label = "CI band", transform = "ci",
+      mapping = list(x_var = "x", y_var = "y")
+    )
+  expect_s3_class(w, "htmlwidget")
+  # Verify auto-injected mapping
+  layer <- w$x$config$layers[[1]]
+  expect_equal(layer$mapping$low_y, "low_y")
+  expect_equal(layer$mapping$high_y, "high_y")
+})
+
+test_that("mean_ci transform accepts x_var + y_var mapping", {
+  df <- data.frame(
+    species = c("A", "A", "A", "B", "B", "B"),
+    value = c(1, 2, 3, 4, 5, 6),
+    stringsAsFactors = FALSE
+  )
+  w <- myIO::myIO(data = df) |>
+    myIO::addIoLayer(
+      type = "rangeBar", label = "mean CI", transform = "mean_ci",
+      mapping = list(x_var = "species", y_var = "value")
+    )
+  expect_s3_class(w, "htmlwidget")
+  layer <- w$x$config$layers[[1]]
+  expect_equal(layer$mapping$low_y, "low_y")
+  expect_equal(layer$mapping$high_y, "high_y")
+})
+
+test_that("auto-injected mapping does not overwrite user-provided values", {
+  df <- data.frame(
+    x = 1:20, y = 1:20, my_low = rep(0, 20), my_high = rep(1, 20),
+    stringsAsFactors = FALSE
+  )
+  mapping <- list(x_var = "x", y_var = "y", low_y = "my_low", high_y = "my_high")
+  injected <- myIO:::inject_transform_mapping("ci", mapping)
+  expect_equal(injected$low_y, "my_low")
+  expect_equal(injected$high_y, "my_high")
+})
+
+test_that("validation still rejects missing x_var for ci transform", {
+  df <- data.frame(y = 1:10, stringsAsFactors = FALSE)
+  expect_error(
+    myIO::myIO(data = df) |>
+      myIO::addIoLayer(type = "area", label = "CI", transform = "ci",
+                       mapping = list(y_var = "y")),
+    "Missing required mapping"
+  )
+})
+
+test_that("inject_transform_mapping is no-op for non-contract transforms", {
+  mapping <- list(x_var = "x", y_var = "y")
+  result <- myIO:::inject_transform_mapping("identity", mapping)
+  expect_equal(result, mapping)
+})

--- a/tests/testthat/test_transform_loess.R
+++ b/tests/testthat/test_transform_loess.R
@@ -1,0 +1,65 @@
+test_that("transform_loess returns smoothed fitted values", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:20,
+    y = sin(1:20) + rnorm(20, sd = 0.1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y"))
+  expect_equal(nrow(result$data), 100)
+  expect_true(all(c("x", "y") %in% colnames(result$data)))
+  expect_equal(result$meta$name, "loess")
+})
+
+test_that("transform_loess respects span option", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:50, y = sin(1:50) + rnorm(50, sd = 0.3),
+    `_source_key` = paste0("row_", 1:50),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  wide <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y"),
+                                 options = list(span = 0.9))
+  narrow <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y"),
+                                   options = list(span = 0.2))
+  # Narrower span = more wiggly = higher variance of fitted values
+  expect_true(var(narrow$data$y) > var(wide$data$y))
+})
+
+test_that("transform_loess warns and returns empty with < 4 points", {
+  df <- data.frame(
+    x = 1:3, y = c(1, 2, 3),
+    `_source_key` = paste0("row_", 1:3),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_warning(
+    result <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y")),
+    "at least 4"
+  )
+  expect_equal(nrow(result$data), 0)
+})
+
+test_that("transform_loess respects n_grid option", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:20, y = 1:20 + rnorm(20),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y"),
+                                   options = list(n_grid = 50))
+  expect_equal(nrow(result$data), 50)
+})
+
+test_that("transform_loess handles NA values", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:10, y = c(1:5, NA, 7:10),
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_loess(df, list(x_var = "x", y_var = "y"))
+  expect_equal(nrow(result$data), 100)
+  expect_true(all(!is.na(result$data$y)))
+})

--- a/tests/testthat/test_transform_mean.R
+++ b/tests/testthat/test_transform_mean.R
@@ -1,0 +1,62 @@
+test_that("transform_mean computes correct group means", {
+  df <- data.frame(
+    group = c("A", "A", "B", "B"),
+    value = c(10, 20, 30, 40),
+    `_source_key` = paste0("row_", 1:4),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_mean(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$data$value[result$data$group == "A"], 15)
+  expect_equal(result$data$value[result$data$group == "B"], 35)
+})
+
+test_that("transform_mean handles NA values", {
+  df <- data.frame(
+    group = c("A", "A", "A"),
+    value = c(10, NA, 20),
+    `_source_key` = paste0("row_", 1:3),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_mean(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$data$value, 15)
+})
+
+test_that("transform_mean returns NA for empty group after NA removal", {
+  df <- data.frame(
+    group = c("A"),
+    value = NA_real_,
+    `_source_key` = "row_1",
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_mean(df, list(x_var = "group", y_var = "value"))
+  expect_true(is.na(result$data$value))
+})
+
+test_that("transform_mean returns one row per group", {
+  df <- data.frame(
+    group = c("A", "A", "B", "B", "C", "C"),
+    value = c(1, 2, 3, 4, 5, 6),
+    `_source_key` = paste0("row_", 1:6),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_mean(df, list(x_var = "group", y_var = "value"))
+  expect_equal(nrow(result$data), 3)
+})
+
+test_that("transform_mean returns correct metadata", {
+  df <- data.frame(
+    group = c("A", "A"),
+    value = c(10, 20),
+    `_source_key` = c("row_1", "row_2"),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_mean(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$meta$name, "mean")
+  expect_equal(result$meta$derivedFrom, "input_rows")
+  expect_equal(result$meta$sourceKeys[[1]], c("row_1", "row_2"))
+})

--- a/tests/testthat/test_transform_mean_ci.R
+++ b/tests/testthat/test_transform_mean_ci.R
@@ -1,0 +1,95 @@
+test_that("mean_ci bounds contain the mean", {
+  df <- data.frame(
+    group = c("A", "A", "A", "A", "A"),
+    value = c(10, 12, 11, 13, 14),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"))
+  expect_true(result$data$low_y <= result$data$value)
+  expect_true(result$data$high_y >= result$data$value)
+})
+
+test_that("level=0.99 is wider than level=0.95", {
+  df <- data.frame(
+    group = rep("A", 20),
+    value = rnorm(20, mean = 10, sd = 2),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  ci_95 <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"),
+                                     options = list(level = 0.95))
+  ci_99 <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"),
+                                     options = list(level = 0.99))
+  width_95 <- ci_95$data$high_y - ci_95$data$low_y
+  width_99 <- ci_99$data$high_y - ci_99$data$low_y
+  expect_true(width_99 > width_95)
+})
+
+test_that("n=1 returns NA bounds", {
+  df <- data.frame(
+    group = "A", value = 42,
+    `_source_key` = "row_1",
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$data$value, 42)
+  expect_true(is.na(result$data$low_y))
+  expect_true(is.na(result$data$high_y))
+})
+
+test_that("t-method matches stats::t.test output", {
+  set.seed(42)
+  values <- rnorm(15, mean = 50, sd = 5)
+  df <- data.frame(
+    group = rep("A", 15), value = values,
+    `_source_key` = paste0("row_", 1:15),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"),
+                                     options = list(method = "t", level = 0.95))
+  t_result <- t.test(values, conf.level = 0.95)
+  expect_equal(result$data$low_y, t_result$conf.int[1], tolerance = 1e-10)
+  expect_equal(result$data$high_y, t_result$conf.int[2], tolerance = 1e-10)
+})
+
+test_that("includes n and se columns", {
+  df <- data.frame(
+    group = c("A", "A", "A", "B", "B"),
+    value = c(1, 2, 3, 10, 20),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"))
+  expect_true("n" %in% colnames(result$data))
+  expect_true("se" %in% colnames(result$data))
+  expect_equal(result$data$n[result$data$group == "A"], 3)
+  expect_equal(result$data$n[result$data$group == "B"], 2)
+})
+
+test_that("se-method uses normal approximation", {
+  set.seed(42)
+  values <- rnorm(100, mean = 50, sd = 5)
+  df <- data.frame(
+    group = rep("A", 100), value = values,
+    `_source_key` = paste0("row_", 1:100),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result_t <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"),
+                                       options = list(method = "t"))
+  result_se <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"),
+                                        options = list(method = "se"))
+  # With n=100, t and normal should be very close
+  expect_equal(result_t$data$low_y, result_se$data$low_y, tolerance = 0.1)
+})
+
+test_that("mean_ci returns correct metadata", {
+  df <- data.frame(
+    group = c("A", "A"), value = c(1, 2),
+    `_source_key` = c("row_1", "row_2"),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_mean_ci(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$meta$name, "mean_ci")
+  expect_equal(result$meta$derivedFrom, "input_rows")
+})

--- a/tests/testthat/test_transform_polynomial.R
+++ b/tests/testthat/test_transform_polynomial.R
@@ -1,0 +1,50 @@
+test_that("transform_polynomial fits quadratic data", {
+  df <- data.frame(
+    x = 1:20,
+    y = (1:20)^2 + rnorm(20, sd = 1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_polynomial(df, list(x_var = "x", y_var = "y"),
+                                        options = list(degree = 2))
+  expect_equal(nrow(result$data), 100)
+  # Quadratic fit should closely match x^2 at endpoints
+  expect_true(abs(result$data$y[100] - 400) < 50)
+  expect_equal(result$meta$name, "polynomial")
+})
+
+test_that("transform_polynomial warns and returns empty when degree >= n", {
+  df <- data.frame(
+    x = 1:3, y = c(1, 4, 9),
+    `_source_key` = paste0("row_", 1:3),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_warning(
+    result <- myIO:::transform_polynomial(df, list(x_var = "x", y_var = "y"),
+                                          options = list(degree = 3)),
+    "more data points"
+  )
+  expect_equal(nrow(result$data), 0)
+})
+
+test_that("transform_polynomial respects n_grid option", {
+  df <- data.frame(
+    x = 1:10, y = (1:10)^2,
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_polynomial(df, list(x_var = "x", y_var = "y"),
+                                        options = list(n_grid = 25))
+  expect_equal(nrow(result$data), 25)
+})
+
+test_that("transform_polynomial returns _source_key in metadata", {
+  df <- data.frame(
+    x = 1:10, y = 1:10,
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_polynomial(df, list(x_var = "x", y_var = "y"))
+  expect_equal(result$meta$derivedFrom, "input_rows")
+  expect_length(result$meta$sourceKeys, 10)
+})

--- a/tests/testthat/test_transform_residuals.R
+++ b/tests/testthat/test_transform_residuals.R
@@ -1,0 +1,68 @@
+test_that("lm residuals sum to approximately zero", {
+  df <- data.frame(
+    x = 1:20, y = 2 * (1:20) + rnorm(20, sd = 1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"))
+  expect_true(abs(sum(result$data$y)) < 1e-10)
+  expect_equal(nrow(result$data), 20)
+})
+
+test_that("residuals have same length as complete cases", {
+  df <- data.frame(
+    x = 1:10, y = c(1:5, NA, 7:10),
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"))
+  expect_equal(nrow(result$data), 9)
+})
+
+test_that("x values are fitted values not original x", {
+  df <- data.frame(
+    x = c(1, 2, 3, 4, 5), y = c(2, 4, 6, 8, 10),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"))
+  fitted_vals <- stats::fitted(lm(df$y ~ df$x))
+  expect_equal(result$data$x, unname(fitted_vals))
+})
+
+test_that("loess method works", {
+  set.seed(42)
+  df <- data.frame(
+    x = 1:20, y = sin(1:20) + rnorm(20, sd = 0.1),
+    `_source_key` = paste0("row_", 1:20),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"),
+                                       options = list(method = "loess"))
+  expect_equal(nrow(result$data), 20)
+  expect_equal(result$meta$name, "residuals")
+})
+
+test_that("polynomial method works", {
+  df <- data.frame(
+    x = 1:15, y = (1:15)^2 + rnorm(15, sd = 1),
+    `_source_key` = paste0("row_", 1:15),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"),
+                                       options = list(method = "polynomial", degree = 2))
+  expect_equal(nrow(result$data), 15)
+})
+
+test_that("unknown method errors", {
+  df <- data.frame(
+    x = 1:5, y = 1:5,
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_error(
+    myIO:::transform_residuals(df, list(x_var = "x", y_var = "y"),
+                               options = list(method = "gam")),
+    "Unknown residuals method"
+  )
+})

--- a/tests/testthat/test_transform_smooth.R
+++ b/tests/testthat/test_transform_smooth.R
@@ -1,0 +1,84 @@
+test_that("SMA with window=3 averages correctly", {
+  df <- data.frame(
+    x = 1:5, y = c(1, 2, 3, 4, 5),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                    options = list(method = "sma", window = 3))
+  # Middle values should be averaged: (1+2+3)/3=2, (2+3+4)/3=3, (3+4+5)/3=4
+  expect_equal(result$data$y, c(2, 3, 4))
+  expect_equal(result$data$x, c(2, 3, 4))
+})
+
+test_that("EMA with alpha=1 returns raw data", {
+  df <- data.frame(
+    x = 1:5, y = c(10, 20, 30, 40, 50),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                    options = list(method = "ema", alpha = 1))
+  expect_equal(result$data$y, c(10, 20, 30, 40, 50))
+})
+
+test_that("EMA with alpha=0 returns constant first value", {
+  df <- data.frame(
+    x = 1:5, y = c(10, 20, 30, 40, 50),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                    options = list(method = "ema", alpha = 0))
+  expect_true(all(result$data$y == 10))
+})
+
+test_that("SMA warns and clamps when window > nrow", {
+  df <- data.frame(
+    x = 1:3, y = c(1, 2, 3),
+    `_source_key` = paste0("row_", 1:3),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_warning(
+    result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                      options = list(method = "sma", window = 10)),
+    "exceeds data length"
+  )
+  expect_true(nrow(result$data) > 0)
+})
+
+test_that("unknown method errors", {
+  df <- data.frame(
+    x = 1:5, y = 1:5,
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_error(
+    myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                            options = list(method = "wma")),
+    "Unknown smooth method"
+  )
+})
+
+test_that("data is sorted by x before smoothing", {
+  df <- data.frame(
+    x = c(3, 1, 2, 5, 4), y = c(30, 10, 20, 50, 40),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                    options = list(method = "sma", window = 3))
+  expect_true(all(diff(result$data$x) > 0))
+})
+
+test_that("transform_smooth returns correct metadata", {
+  df <- data.frame(
+    x = 1:10, y = 1:10,
+    `_source_key` = paste0("row_", 1:10),
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  result <- myIO:::transform_smooth(df, list(x_var = "x", y_var = "y"),
+                                    options = list(method = "ema"))
+  expect_equal(result$meta$name, "smooth")
+  expect_equal(result$meta$derivedFrom, "input_rows")
+})

--- a/tests/testthat/test_transform_summary.R
+++ b/tests/testthat/test_transform_summary.R
@@ -1,0 +1,78 @@
+test_that("summary count returns number of non-NA values per group", {
+  df <- data.frame(
+    group = c("A", "A", "B", "B", "B"),
+    value = c(1, NA, 3, 4, 5),
+    `_source_key` = paste0("row_", 1:5),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_summary(df, list(x_var = "group", y_var = "value"),
+                                     options = list(stat = "count"))
+  expect_equal(result$data$value[result$data$group == "A"], 1)
+  expect_equal(result$data$value[result$data$group == "B"], 3)
+})
+
+test_that("summary sum returns correct totals", {
+  df <- data.frame(
+    group = c("A", "A", "B", "B"),
+    value = c(10, 20, 30, 40),
+    `_source_key` = paste0("row_", 1:4),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_summary(df, list(x_var = "group", y_var = "value"),
+                                     options = list(stat = "sum"))
+  expect_equal(result$data$value[result$data$group == "A"], 30)
+  expect_equal(result$data$value[result$data$group == "B"], 70)
+})
+
+test_that("summary sd returns correct standard deviation", {
+  df <- data.frame(
+    group = c("A", "A", "A", "A"),
+    value = c(2, 4, 4, 4),
+    `_source_key` = paste0("row_", 1:4),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_summary(df, list(x_var = "group", y_var = "value"),
+                                     options = list(stat = "sd"))
+  expect_equal(result$data$value, sd(c(2, 4, 4, 4)))
+})
+
+test_that("summary defaults to count", {
+  df <- data.frame(
+    group = c("A", "A"),
+    value = c(1, 2),
+    `_source_key` = c("row_1", "row_2"),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_summary(df, list(x_var = "group", y_var = "value"))
+  expect_equal(result$data$value, 2)
+})
+
+test_that("summary errors on unknown stat", {
+  df <- data.frame(
+    group = "A", value = 1, `_source_key` = "row_1",
+    stringsAsFactors = FALSE, check.names = FALSE
+  )
+  expect_error(
+    myIO:::transform_summary(df, list(x_var = "group", y_var = "value"),
+                             options = list(stat = "banana")),
+    "Unknown stat"
+  )
+})
+
+test_that("summary returns correct metadata", {
+  df <- data.frame(
+    group = c("A", "B"),
+    value = c(1, 2),
+    `_source_key` = c("row_1", "row_2"),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  result <- myIO:::transform_summary(df, list(x_var = "group", y_var = "value"),
+                                     options = list(stat = "sum"))
+  expect_equal(result$meta$name, "summary")
+  expect_equal(result$meta$derivedFrom, "input_rows")
+})


### PR DESCRIPTION
## Summary

- Adds 8 composable statistical transforms (CI bands, LOESS, polynomial regression, moving averages, group mean/CI, residuals, summary stats) to myIO's transform pipeline — directly addressing the top validated user pain points in the R interactive viz ecosystem
- Adds `composite_regression` for one-call scatter + trend line + CI band + R² annotation, and a new `TextRenderer` in JS for statistical annotations
- Zero new dependencies — all computation uses base R `stats` package

## What changed

- **R transforms** (8 new files): `transform_ci`, `transform_loess`, `transform_polynomial`, `transform_smooth`, `transform_mean`, `transform_mean_ci`, `transform_residuals`, `transform_summary`
- **R composite** (1 new file): `composite_regression` — expands to scatter + trend + CI band + R² annotation sublayers, with per-group support
- **R validation** (addIoLayer.R): `TRANSFORM_INPUT_CONTRACTS` map enables transforms that produce output columns (`low_y`, `high_y`) not in user input data. Auto-injects mapping for `ci` and `mean_ci` transforms.
- **JS renderers** (1 new file): `TextRenderer` for corner-positioned text annotations (R², equations)
- **JS scales** (scales.js): Filters non-axes layers from extent computation to prevent NaN pollution
- **JS LineRenderer**: Expanded point suppression to cover `loess`, `polynomial`, `smooth` transforms
- **R registries** (util.R, transform_registry.R): Updated `ALLOWED_TYPES`, `VALID_COMBINATIONS`, `COMPATIBILITY_GROUPS`, `composite_registry`, `transform_registry`

## Test plan

- [x] R tests pass: 485 tests, 0 failures (`devtools::test()`)
- [x] JS tests pass: 162 tests, 0 failures (`npm run test`)
- [x] Zero regressions from 358 → 485 R tests
- [x] E2E integration tests cover all new chart types (regression composite, scatter+CI, LOESS, mean±CI, moving average, residuals)
- [ ] Manual verification: open E2E HTML files in browser to visually confirm rendering

## Archived references

Pipeline docs archived to `md/archive/` in this PR:
- `md/archive/statistics-augmentation-contract.md`
- `md/archive/statistics-augmentation-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)