### PR TITLE
Add lollipop and dumbbell chart types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # myIO 1.2.0 (development)
 
+## New chart types
+
+* `lollipop` — vertical stem with circle head, supports `mean` and `summary`
+  transforms. Compatible with categorical x-axis charts.
+* `dumbbell` — connected dots showing a range between `low_y` and `high_y`.
+  Both types support `flipAxis` and themed colors.
+
 ## Small multiples / faceting
 
 * `setFacet(var, ncol, scales)` splits charts into a CSS grid of panels, one per

--- a/R/addIoLayer.R
+++ b/R/addIoLayer.R
@@ -214,6 +214,7 @@ validate_layer_inputs <- function(type, transform, mapping, label, data, existin
       rangeBar = c("x_var", "low_y", "high_y"),
       area = c("x_var", "low_y", "high_y"),
       hexbin = c("x_var", "y_var", "radius"),
+      dumbbell = c("x_var", "low_y", "high_y"),
       c("x_var", "y_var")
     )
   }

--- a/R/util.R
+++ b/R/util.R
@@ -29,7 +29,8 @@ ALLOWED_TYPES <- c(
   "donut", "area", "groupedBar", "histogram", "heatmap",
   "candlestick", "waterfall", "sankey", "boxplot", "violin",
   "ridgeline", "rangeBar", "text", "regression", "bracket",
-  "comparison", "qq"
+  "comparison", "qq",
+  "lollipop", "dumbbell"
 )
 
 COMPATIBILITY_GROUPS <- list(
@@ -55,7 +56,9 @@ COMPATIBILITY_GROUPS <- list(
   regression = "axes-continuous",
   bracket = "axes-continuous",
   comparison = "axes-categorical",
-  qq = "axes-continuous"
+  qq = "axes-continuous",
+  lollipop = "axes-categorical",
+  dumbbell = "axes-categorical"
 )
 
 GROUP_MATRIX <- list(
@@ -90,7 +93,9 @@ VALID_COMBINATIONS <- list(
   donut = c("identity"),
   gauge = c("identity"),
   text = c("identity"),
-  bracket = c("identity", "pairwise_test")
+  bracket = c("identity", "pairwise_test"),
+  lollipop = c("identity", "mean", "summary"),
+  dumbbell = c("identity")
 )
 
 composite_registry <- function() {

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -2460,6 +2460,211 @@
     }
   };
 
+  // inst/htmlwidgets/myIO/src/renderers/LollipopRenderer.js
+  var LollipopRenderer = class {
+    static type = "lollipop";
+    static traits = {
+      hasAxes: true,
+      referenceLines: true,
+      legendType: "layer",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: { invertX: false }
+    };
+    static scaleHints = {
+      xScaleType: "band",
+      yScaleType: "linear",
+      xExtentFields: [],
+      yExtentFields: ["y_var"],
+      domainMerge: "union"
+    };
+    static dataContract = {
+      x_var: { required: true, numeric: false },
+      y_var: { required: true, numeric: true }
+    };
+    render(chart, layer, layers) {
+      var xScale = chart.derived.xScale;
+      var yScale = chart.derived.yScale;
+      var flipAxis = chart.config.scales.flipAxis;
+      var speed = chart.config.transitions.speed;
+      var group = chart.dom.chartArea.selectAll(".tag-lollipop-" + layer.id).data([null]).join("g").attr("class", "tag-lollipop-" + layer.id);
+      var headRadius = layer.options && layer.options.headRadius || 5;
+      var stemWidth = layer.options && layer.options.stemWidth || 2;
+      var xVar = layer.mapping.x_var;
+      var yVar = layer.mapping.y_var;
+      var bandOffset = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
+      var baseline = typeof yScale(0) === "number" ? yScale(0) : yScale.range()[0];
+      var stems = group.selectAll(".lollipop-stem").data(layer.data, function(d) {
+        return d._source_key;
+      });
+      stems.exit().transition().duration(speed).style("opacity", 0).remove();
+      if (flipAxis) {
+        stems.join("line").attr("class", "lollipop-stem").transition().duration(speed).attr("x1", 0).attr("x2", function(d) {
+          return xScale(d[xVar]);
+        }).attr("y1", function(d) {
+          return yScale(d[yVar]) + bandOffset;
+        }).attr("y2", function(d) {
+          return yScale(d[yVar]) + bandOffset;
+        }).attr("stroke", layer.color).attr("stroke-width", stemWidth);
+      } else {
+        stems.join("line").attr("class", "lollipop-stem").transition().duration(speed).attr("x1", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("x2", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("y1", baseline).attr("y2", function(d) {
+          return yScale(d[yVar]);
+        }).attr("stroke", layer.color).attr("stroke-width", stemWidth);
+      }
+      var heads = group.selectAll(".lollipop-head").data(layer.data, function(d) {
+        return d._source_key;
+      });
+      heads.exit().transition().duration(speed).style("opacity", 0).remove();
+      if (flipAxis) {
+        heads.join("circle").attr("class", "lollipop-head").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[xVar]);
+        }).attr("cy", function(d) {
+          return yScale(d[yVar]) + bandOffset;
+        }).attr("r", headRadius).attr("fill", layer.color);
+      } else {
+        heads.join("circle").attr("class", "lollipop-head").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("cy", function(d) {
+          return yScale(d[yVar]);
+        }).attr("r", headRadius).attr("fill", layer.color);
+      }
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-lollipop-" + layer.id + " .lollipop-head";
+    }
+    formatTooltip(chart, d, layer) {
+      var yFormat = chart.runtime.activeYFormat || d3.format("s");
+      return {
+        title: { text: String(d[layer.mapping.x_var]) },
+        items: [{
+          color: layer.color,
+          label: layer.label,
+          value: yFormat(d[layer.mapping.y_var])
+        }]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-lollipop-" + layer.id).remove();
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/renderers/DumbbellRenderer.js
+  var DumbbellRenderer = class {
+    static type = "dumbbell";
+    static traits = {
+      hasAxes: true,
+      referenceLines: true,
+      legendType: "layer",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: { invertX: false }
+    };
+    static scaleHints = {
+      xScaleType: "band",
+      yScaleType: "linear",
+      xExtentFields: [],
+      yExtentFields: ["low_y", "high_y"],
+      domainMerge: "union"
+    };
+    static dataContract = {
+      x_var: { required: true, numeric: false },
+      low_y: { required: true, numeric: true },
+      high_y: { required: true, numeric: true }
+    };
+    render(chart, layer, layers) {
+      var xScale = chart.derived.xScale;
+      var yScale = chart.derived.yScale;
+      var flipAxis = chart.config.scales.flipAxis;
+      var speed = chart.config.transitions.speed;
+      var group = chart.dom.chartArea.selectAll(".tag-dumbbell-" + layer.id).data([null]).join("g").attr("class", "tag-dumbbell-" + layer.id);
+      var dotRadius = layer.options && layer.options.dotRadius || 5;
+      var lineWidth = layer.options && layer.options.lineWidth || 2;
+      var xVar = layer.mapping.x_var;
+      var lowVar = layer.mapping.low_y;
+      var highVar = layer.mapping.high_y;
+      var bandOffset = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
+      var lines = group.selectAll(".dumbbell-line").data(layer.data, function(d) {
+        return d._source_key;
+      });
+      lines.exit().transition().duration(speed).style("opacity", 0).remove();
+      if (flipAxis) {
+        lines.join("line").attr("class", "dumbbell-line").transition().duration(speed).attr("x1", function(d) {
+          return xScale(d[lowVar]);
+        }).attr("x2", function(d) {
+          return xScale(d[highVar]);
+        }).attr("y1", function(d) {
+          return yScale(d[xVar]) + bandOffset;
+        }).attr("y2", function(d) {
+          return yScale(d[xVar]) + bandOffset;
+        }).attr("stroke", "var(--chart-grid-color, #ccc)").attr("stroke-width", lineWidth);
+      } else {
+        lines.join("line").attr("class", "dumbbell-line").transition().duration(speed).attr("x1", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("x2", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("y1", function(d) {
+          return yScale(d[lowVar]);
+        }).attr("y2", function(d) {
+          return yScale(d[highVar]);
+        }).attr("stroke", "var(--chart-grid-color, #ccc)").attr("stroke-width", lineWidth);
+      }
+      var lowDots = group.selectAll(".dumbbell-low").data(layer.data, function(d) {
+        return d._source_key;
+      });
+      lowDots.exit().transition().duration(speed).style("opacity", 0).remove();
+      if (flipAxis) {
+        lowDots.join("circle").attr("class", "dumbbell-low").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[lowVar]);
+        }).attr("cy", function(d) {
+          return yScale(d[xVar]) + bandOffset;
+        }).attr("r", dotRadius).attr("fill", layer.color).attr("opacity", 0.6);
+      } else {
+        lowDots.join("circle").attr("class", "dumbbell-low").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("cy", function(d) {
+          return yScale(d[lowVar]);
+        }).attr("r", dotRadius).attr("fill", layer.color).attr("opacity", 0.6);
+      }
+      var highDots = group.selectAll(".dumbbell-high").data(layer.data, function(d) {
+        return d._source_key;
+      });
+      highDots.exit().transition().duration(speed).style("opacity", 0).remove();
+      if (flipAxis) {
+        highDots.join("circle").attr("class", "dumbbell-high").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[highVar]);
+        }).attr("cy", function(d) {
+          return yScale(d[xVar]) + bandOffset;
+        }).attr("r", dotRadius).attr("fill", layer.color);
+      } else {
+        highDots.join("circle").attr("class", "dumbbell-high").transition().duration(speed).attr("cx", function(d) {
+          return xScale(d[xVar]) + bandOffset;
+        }).attr("cy", function(d) {
+          return yScale(d[highVar]);
+        }).attr("r", dotRadius).attr("fill", layer.color);
+      }
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-dumbbell-" + layer.id + " .dumbbell-high, .tag-dumbbell-" + layer.id + " .dumbbell-low";
+    }
+    formatTooltip(chart, d, layer) {
+      var yFormat = chart.runtime.activeYFormat || d3.format("s");
+      return {
+        title: { text: String(d[layer.mapping.x_var]) },
+        items: [
+          { color: layer.color, label: "Low", value: yFormat(d[layer.mapping.low_y]) },
+          { color: layer.color, label: "High", value: yFormat(d[layer.mapping.high_y]) }
+        ]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-dumbbell-" + layer.id).remove();
+    }
+  };
+
   // inst/htmlwidgets/myIO/src/registry.js
   var rendererRegistry = /* @__PURE__ */ new Map();
   function registerRenderer(type, RendererClass) {
@@ -2532,6 +2737,12 @@
     }
     if (!rendererRegistry.has(RangeBarRenderer.type)) {
       registerRenderer(RangeBarRenderer.type, new RangeBarRenderer());
+    }
+    if (!rendererRegistry.has(LollipopRenderer.type)) {
+      registerRenderer(LollipopRenderer.type, new LollipopRenderer());
+    }
+    if (!rendererRegistry.has(DumbbellRenderer.type)) {
+      registerRenderer(DumbbellRenderer.type, new DumbbellRenderer());
     }
     if (!rendererRegistry.has(TextRenderer.type)) {
       registerRenderer(TextRenderer.type, new TextRenderer());

--- a/inst/htmlwidgets/myIO/src/registry.js
+++ b/inst/htmlwidgets/myIO/src/registry.js
@@ -17,6 +17,8 @@ import { SankeyRenderer } from "./renderers/SankeyRenderer.js";
 import { RangeBarRenderer } from "./renderers/RangeBarRenderer.js";
 import { TextRenderer } from "./renderers/TextRenderer.js";
 import { BracketRenderer } from "./renderers/BracketRenderer.js";
+import { LollipopRenderer } from "./renderers/LollipopRenderer.js";
+import { DumbbellRenderer } from "./renderers/DumbbellRenderer.js";
 
 export function registerRenderer(type, RendererClass) {
   if (rendererRegistry.has(type)) {
@@ -94,6 +96,12 @@ export function registerBuiltInRenderers() {
   }
   if (!rendererRegistry.has(RangeBarRenderer.type)) {
     registerRenderer(RangeBarRenderer.type, new RangeBarRenderer());
+  }
+  if (!rendererRegistry.has(LollipopRenderer.type)) {
+    registerRenderer(LollipopRenderer.type, new LollipopRenderer());
+  }
+  if (!rendererRegistry.has(DumbbellRenderer.type)) {
+    registerRenderer(DumbbellRenderer.type, new DumbbellRenderer());
   }
 
   if (!rendererRegistry.has(TextRenderer.type)) {

--- a/inst/htmlwidgets/myIO/src/renderers/DumbbellRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/DumbbellRenderer.js
@@ -1,0 +1,150 @@
+export class DumbbellRenderer {
+  static type = "dumbbell";
+  static traits = {
+    hasAxes: true,
+    referenceLines: true,
+    legendType: "layer",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: { invertX: false }
+  };
+  static scaleHints = {
+    xScaleType: "band",
+    yScaleType: "linear",
+    xExtentFields: [],
+    yExtentFields: ["low_y", "high_y"],
+    domainMerge: "union"
+  };
+  static dataContract = {
+    x_var: { required: true, numeric: false },
+    low_y: { required: true, numeric: true },
+    high_y: { required: true, numeric: true }
+  };
+
+  render(chart, layer, layers) {
+    var xScale = chart.derived.xScale;
+    var yScale = chart.derived.yScale;
+    var flipAxis = chart.config.scales.flipAxis;
+    var speed = chart.config.transitions.speed;
+    var group = chart.dom.chartArea.selectAll(".tag-dumbbell-" + layer.id)
+      .data([null]).join("g").attr("class", "tag-dumbbell-" + layer.id);
+
+    var dotRadius = (layer.options && layer.options.dotRadius) || 5;
+    var lineWidth = (layer.options && layer.options.lineWidth) || 2;
+    var xVar = layer.mapping.x_var;
+    var lowVar = layer.mapping.low_y;
+    var highVar = layer.mapping.high_y;
+    var bandOffset = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
+    var lines = group.selectAll(".dumbbell-line")
+      .data(layer.data, function(d) { return d._source_key; });
+
+    lines.exit()
+      .transition()
+      .duration(speed)
+      .style("opacity", 0)
+      .remove();
+
+    if (flipAxis) {
+      lines.join("line")
+        .attr("class", "dumbbell-line")
+        .transition()
+        .duration(speed)
+        .attr("x1", function(d) { return xScale(d[lowVar]); })
+        .attr("x2", function(d) { return xScale(d[highVar]); })
+        .attr("y1", function(d) { return yScale(d[xVar]) + bandOffset; })
+        .attr("y2", function(d) { return yScale(d[xVar]) + bandOffset; })
+        .attr("stroke", "var(--chart-grid-color, #ccc)")
+        .attr("stroke-width", lineWidth);
+    } else {
+      lines.join("line")
+        .attr("class", "dumbbell-line")
+        .transition()
+        .duration(speed)
+        .attr("x1", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("x2", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("y1", function(d) { return yScale(d[lowVar]); })
+        .attr("y2", function(d) { return yScale(d[highVar]); })
+        .attr("stroke", "var(--chart-grid-color, #ccc)")
+        .attr("stroke-width", lineWidth);
+    }
+
+    var lowDots = group.selectAll(".dumbbell-low")
+      .data(layer.data, function(d) { return d._source_key; });
+
+    lowDots.exit()
+      .transition()
+      .duration(speed)
+      .style("opacity", 0)
+      .remove();
+
+    if (flipAxis) {
+      lowDots.join("circle")
+        .attr("class", "dumbbell-low")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[lowVar]); })
+        .attr("cy", function(d) { return yScale(d[xVar]) + bandOffset; })
+        .attr("r", dotRadius)
+        .attr("fill", layer.color)
+        .attr("opacity", 0.6);
+    } else {
+      lowDots.join("circle")
+        .attr("class", "dumbbell-low")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("cy", function(d) { return yScale(d[lowVar]); })
+        .attr("r", dotRadius)
+        .attr("fill", layer.color)
+        .attr("opacity", 0.6);
+    }
+
+    var highDots = group.selectAll(".dumbbell-high")
+      .data(layer.data, function(d) { return d._source_key; });
+
+    highDots.exit()
+      .transition()
+      .duration(speed)
+      .style("opacity", 0)
+      .remove();
+
+    if (flipAxis) {
+      highDots.join("circle")
+        .attr("class", "dumbbell-high")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[highVar]); })
+        .attr("cy", function(d) { return yScale(d[xVar]) + bandOffset; })
+        .attr("r", dotRadius)
+        .attr("fill", layer.color);
+    } else {
+      highDots.join("circle")
+        .attr("class", "dumbbell-high")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("cy", function(d) { return yScale(d[highVar]); })
+        .attr("r", dotRadius)
+        .attr("fill", layer.color);
+    }
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-dumbbell-" + layer.id + " .dumbbell-high, .tag-dumbbell-" + layer.id + " .dumbbell-low";
+  }
+
+  formatTooltip(chart, d, layer) {
+    var yFormat = chart.runtime.activeYFormat || d3.format("s");
+    return {
+      title: { text: String(d[layer.mapping.x_var]) },
+      items: [
+        { color: layer.color, label: "Low", value: yFormat(d[layer.mapping.low_y]) },
+        { color: layer.color, label: "High", value: yFormat(d[layer.mapping.high_y]) }
+      ]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-dumbbell-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/src/renderers/LollipopRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/LollipopRenderer.js
@@ -1,0 +1,119 @@
+export class LollipopRenderer {
+  static type = "lollipop";
+  static traits = {
+    hasAxes: true,
+    referenceLines: true,
+    legendType: "layer",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: { invertX: false }
+  };
+  static scaleHints = {
+    xScaleType: "band",
+    yScaleType: "linear",
+    xExtentFields: [],
+    yExtentFields: ["y_var"],
+    domainMerge: "union"
+  };
+  static dataContract = {
+    x_var: { required: true, numeric: false },
+    y_var: { required: true, numeric: true }
+  };
+
+  render(chart, layer, layers) {
+    var xScale = chart.derived.xScale;
+    var yScale = chart.derived.yScale;
+    var flipAxis = chart.config.scales.flipAxis;
+    var speed = chart.config.transitions.speed;
+    var group = chart.dom.chartArea.selectAll(".tag-lollipop-" + layer.id)
+      .data([null]).join("g").attr("class", "tag-lollipop-" + layer.id);
+
+    var headRadius = (layer.options && layer.options.headRadius) || 5;
+    var stemWidth = (layer.options && layer.options.stemWidth) || 2;
+    var xVar = layer.mapping.x_var;
+    var yVar = layer.mapping.y_var;
+    var bandOffset = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
+    var baseline = typeof yScale(0) === "number" ? yScale(0) : yScale.range()[0];
+    var stems = group.selectAll(".lollipop-stem")
+      .data(layer.data, function(d) { return d._source_key; });
+
+    stems.exit()
+      .transition()
+      .duration(speed)
+      .style("opacity", 0)
+      .remove();
+
+    if (flipAxis) {
+      stems.join("line")
+        .attr("class", "lollipop-stem")
+        .transition()
+        .duration(speed)
+        .attr("x1", 0)
+        .attr("x2", function(d) { return xScale(d[xVar]); })
+        .attr("y1", function(d) { return yScale(d[yVar]) + bandOffset; })
+        .attr("y2", function(d) { return yScale(d[yVar]) + bandOffset; })
+        .attr("stroke", layer.color)
+        .attr("stroke-width", stemWidth);
+    } else {
+      stems.join("line")
+        .attr("class", "lollipop-stem")
+        .transition()
+        .duration(speed)
+        .attr("x1", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("x2", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("y1", baseline)
+        .attr("y2", function(d) { return yScale(d[yVar]); })
+        .attr("stroke", layer.color)
+        .attr("stroke-width", stemWidth);
+    }
+
+    var heads = group.selectAll(".lollipop-head")
+      .data(layer.data, function(d) { return d._source_key; });
+
+    heads.exit()
+      .transition()
+      .duration(speed)
+      .style("opacity", 0)
+      .remove();
+
+    if (flipAxis) {
+      heads.join("circle")
+        .attr("class", "lollipop-head")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[xVar]); })
+        .attr("cy", function(d) { return yScale(d[yVar]) + bandOffset; })
+        .attr("r", headRadius)
+        .attr("fill", layer.color);
+    } else {
+      heads.join("circle")
+        .attr("class", "lollipop-head")
+        .transition()
+        .duration(speed)
+        .attr("cx", function(d) { return xScale(d[xVar]) + bandOffset; })
+        .attr("cy", function(d) { return yScale(d[yVar]); })
+        .attr("r", headRadius)
+        .attr("fill", layer.color);
+    }
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-lollipop-" + layer.id + " .lollipop-head";
+  }
+
+  formatTooltip(chart, d, layer) {
+    var yFormat = chart.runtime.activeYFormat || d3.format("s");
+    return {
+      title: { text: String(d[layer.mapping.x_var]) },
+      items: [{
+        color: layer.color,
+        label: layer.label,
+        value: yFormat(d[layer.mapping.y_var])
+      }]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-lollipop-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/style.css
+++ b/inst/htmlwidgets/myIO/style.css
@@ -772,3 +772,13 @@
     grid-template-columns: repeat(2, 1fr) !important;
   }
 }
+
+/* Lollipop */
+.lollipop-stem { shape-rendering: crispEdges; }
+.lollipop-head { cursor: pointer; transition: r 0.15s ease; }
+.lollipop-head:hover { r: 7; }
+
+/* Dumbbell */
+.dumbbell-line { shape-rendering: crispEdges; }
+.dumbbell-low, .dumbbell-high { cursor: pointer; transition: r 0.15s ease; }
+.dumbbell-low:hover, .dumbbell-high:hover { r: 7; }

--- a/tests/testthat/test_dumbbell.R
+++ b/tests/testthat/test_dumbbell.R
@@ -1,0 +1,53 @@
+# Contract tests for dumbbell chart type (v1.2)
+
+test_that("dumbbell layer accepts valid inputs", {
+  df <- data.frame(
+    category = c("A", "B", "C"),
+    low = c(10, 20, 15),
+    high = c(30, 40, 25)
+  )
+  p <- myIO(df) |>
+    addIoLayer("dumbbell", label = "db",
+               mapping = list(x_var = "category", low_y = "low", high_y = "high"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "dumbbell")
+})
+
+test_that("dumbbell rejects missing low_y", {
+  df <- data.frame(category = "A", high = 30)
+  expect_error(
+    myIO(df) |>
+      addIoLayer("dumbbell", label = "db",
+                 mapping = list(x_var = "category", high_y = "high")),
+    "low_y"
+  )
+})
+
+test_that("dumbbell rejects missing high_y", {
+  df <- data.frame(category = "A", low = 10)
+  expect_error(
+    myIO(df) |>
+      addIoLayer("dumbbell", label = "db",
+                 mapping = list(x_var = "category", low_y = "low")),
+    "high_y"
+  )
+})
+
+test_that("dumbbell only supports identity transform", {
+  df <- data.frame(category = "A", low = 10, high = 30)
+  expect_error(
+    myIO(df) |>
+      addIoLayer("dumbbell", label = "db",
+                 mapping = list(x_var = "category", low_y = "low", high_y = "high"),
+                 transform = "mean"),
+    "not valid"
+  )
+})
+
+test_that("dumbbell is in axes-categorical group", {
+  df <- data.frame(category = c("A", "B"), low = c(10, 20), high = c(30, 40))
+  p <- myIO(df) |>
+    addIoLayer("dumbbell", label = "db",
+               mapping = list(x_var = "category", low_y = "low", high_y = "high"))
+  expect_length(p$x$config$layers, 1)
+})

--- a/tests/testthat/test_lollipop.R
+++ b/tests/testthat/test_lollipop.R
@@ -1,0 +1,40 @@
+# Contract tests for lollipop chart type (v1.2)
+
+test_that("lollipop layer accepts valid inputs", {
+  df <- aggregate(mpg ~ cyl, mtcars, mean)
+  p <- myIO(df) |>
+    addIoLayer("lollipop", label = "lp",
+               data = df,
+               mapping = list(x_var = "cyl", y_var = "mpg"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "lollipop")
+})
+
+test_that("lollipop rejects missing y_var", {
+  expect_error(
+    myIO(mtcars) |>
+      addIoLayer("lollipop", label = "lp",
+                 mapping = list(x_var = "cyl")),
+    "y_var"
+  )
+})
+
+test_that("lollipop supports mean transform", {
+  p <- myIO(mtcars) |>
+    addIoLayer("lollipop", label = "lp",
+               mapping = list(x_var = "cyl", y_var = "mpg"),
+               transform = "mean")
+  expect_equal(p$x$config$layers[[1]]$transform, "mean")
+})
+
+test_that("lollipop is in axes-categorical group", {
+  df <- aggregate(mpg ~ cyl, mtcars, mean)
+  # Should be compatible with bar (also axes-categorical)
+  p <- myIO(df) |>
+    addIoLayer("bar", label = "bars",
+               mapping = list(x_var = "cyl", y_var = "mpg")) |>
+    addIoLayer("lollipop", label = "lp",
+               data = df,
+               mapping = list(x_var = "cyl", y_var = "mpg"))
+  expect_length(p$x$config$layers, 2)
+})


### PR DESCRIPTION
## Summary

- Adds `lollipop` chart type: vertical stem with circle head for categorical x-axis data, supports `mean` and `summary` transforms
- Adds `dumbbell` chart type: connected dots showing a range between `low_y` and `high_y`
- Both support `flipAxis`, themed colors, and standard tooltip formatting

## What changed

- **R infrastructure**: Added both types to `ALLOWED_TYPES`, `COMPATIBILITY_GROUPS` (axes-categorical), `VALID_COMBINATIONS`, and required mapping validation in `addIoLayer()`
- **JS**: `LollipopRenderer` and `DumbbellRenderer` with full renderer interface (render, getHoverSelector, formatTooltip, remove). Registered in `registry.js`
- **CSS**: Crisp stem rendering, hover enlargement on circle heads

## Test plan

- [x] R tests: 709/709 pass (5 lollipop + 6 dumbbell tests)
- [x] JS tests: 188/188 pass
- [x] Build: 223.2kb bundle
- [ ] Manual: render lollipop with `aggregate(mpg ~ cyl, mtcars, mean)`
- [ ] Manual: render dumbbell with low/high range data

Remaining chart types (beeswarm, waffle, bump) will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)