### PR TITLE
Add waffle, beeswarm, and bump chart types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,10 @@
 * `lollipop` — vertical stem with circle head, supports `mean` and `summary`
   transforms. Compatible with categorical x-axis charts.
 * `dumbbell` — connected dots showing a range between `low_y` and `high_y`.
-  Both types support `flipAxis` and themed colors.
+* `waffle` — 10x10 grid of colored squares representing proportions. Standalone.
+* `beeswarm` — dodge-positioned points to avoid overlap. Inline dodge algorithm.
+* `bump` — smooth S-curves showing rank/value changes over time with grouped lines.
+  All new types support themed colors and standard tooltip formatting.
 
 ## Small multiples / faceting
 

--- a/R/addIoLayer.R
+++ b/R/addIoLayer.R
@@ -215,6 +215,8 @@ validate_layer_inputs <- function(type, transform, mapping, label, data, existin
       area = c("x_var", "low_y", "high_y"),
       hexbin = c("x_var", "y_var", "radius"),
       dumbbell = c("x_var", "low_y", "high_y"),
+      waffle = c("category", "value"),
+      bump = c("x_var", "y_var", "group"),
       c("x_var", "y_var")
     )
   }

--- a/R/util.R
+++ b/R/util.R
@@ -30,7 +30,8 @@ ALLOWED_TYPES <- c(
   "candlestick", "waterfall", "sankey", "boxplot", "violin",
   "ridgeline", "rangeBar", "text", "regression", "bracket",
   "comparison", "qq",
-  "lollipop", "dumbbell"
+  "lollipop", "dumbbell",
+  "waffle", "beeswarm", "bump"
 )
 
 COMPATIBILITY_GROUPS <- list(
@@ -58,7 +59,10 @@ COMPATIBILITY_GROUPS <- list(
   comparison = "axes-categorical",
   qq = "axes-continuous",
   lollipop = "axes-categorical",
-  dumbbell = "axes-categorical"
+  dumbbell = "axes-categorical",
+  waffle = "standalone-waffle",
+  beeswarm = "axes-continuous",
+  bump = "axes-continuous"
 )
 
 GROUP_MATRIX <- list(
@@ -70,7 +74,8 @@ GROUP_MATRIX <- list(
   "standalone-flow" = c("standalone-flow"),
   "standalone-treemap" = c("standalone-treemap"),
   "standalone-donut" = c("standalone-donut"),
-  "standalone-gauge" = c("standalone-gauge")
+  "standalone-gauge" = c("standalone-gauge"),
+  "standalone-waffle" = c("standalone-waffle")
 )
 
 VALID_COMBINATIONS <- list(
@@ -95,7 +100,10 @@ VALID_COMBINATIONS <- list(
   text = c("identity"),
   bracket = c("identity", "pairwise_test"),
   lollipop = c("identity", "mean", "summary"),
-  dumbbell = c("identity")
+  dumbbell = c("identity"),
+  waffle = c("identity"),
+  beeswarm = c("identity"),
+  bump = c("identity")
 )
 
 composite_registry <- function() {

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -2665,6 +2665,238 @@
     }
   };
 
+  // inst/htmlwidgets/myIO/src/renderers/WaffleRenderer.js
+  var WaffleRenderer = class {
+    static type = "waffle";
+    static traits = {
+      hasAxes: false,
+      referenceLines: false,
+      legendType: "ordinal",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: {}
+    };
+    static scaleHints = null;
+    static dataContract = {
+      category: { required: true },
+      value: { required: true, numeric: true }
+    };
+    render(chart, layer) {
+      var rows = layer.options && layer.options.rows || 10;
+      var cols = layer.options && layer.options.cols || 10;
+      var totalCells = rows * cols;
+      var cellGap = layer.options && layer.options.cellGap || 2;
+      var cellRadius = layer.options && layer.options.cellRadius || 2;
+      var m = chart.config.layout.margin;
+      var chartWidth = chart.runtime.width - m.left - m.right;
+      var chartHeight = chart.runtime.height - m.top - m.bottom;
+      var cellSize = Math.min(
+        (chartWidth - (cols - 1) * cellGap) / cols,
+        (chartHeight - (rows - 1) * cellGap) / rows
+      );
+      var total = 0;
+      for (var i = 0; i < layer.data.length; i++) {
+        total += layer.data[i][layer.mapping.value];
+      }
+      var cells = [];
+      var cellIndex = 0;
+      var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+      for (var i = 0; i < layer.data.length; i++) {
+        var d = layer.data[i];
+        var count = Math.round(d[layer.mapping.value] / total * totalCells);
+        for (var j = 0; j < count && cellIndex < totalCells; j++) {
+          cells.push({
+            category: d[layer.mapping.category],
+            row: Math.floor(cellIndex / cols),
+            col: cellIndex % cols,
+            color: colorScale(d[layer.mapping.category]),
+            datum: d,
+            _source_key: d._source_key
+          });
+          cellIndex++;
+        }
+      }
+      var gridWidth = cols * cellSize + (cols - 1) * cellGap;
+      var gridHeight = rows * cellSize + (rows - 1) * cellGap;
+      var offsetX = (chartWidth - gridWidth) / 2;
+      var offsetY = (chartHeight - gridHeight) / 2;
+      var group = chart.dom.chartArea.selectAll(".tag-waffle-" + layer.id).data([null]).join("g").attr("class", "tag-waffle-" + layer.id).attr("transform", "translate(" + offsetX + "," + offsetY + ")");
+      group.selectAll(".waffle-cell").data(cells).join("rect").attr("class", "waffle-cell").attr("x", function(d2) {
+        return d2.col * (cellSize + cellGap);
+      }).attr("y", function(d2) {
+        return d2.row * (cellSize + cellGap);
+      }).attr("width", cellSize).attr("height", cellSize).attr("rx", cellRadius).attr("fill", function(d2) {
+        return d2.color;
+      });
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-waffle-" + layer.id + " .waffle-cell";
+    }
+    formatTooltip(chart, d, layer) {
+      return {
+        title: { text: d.category },
+        items: [{ color: d.color, label: d.category, value: String(d.datum[layer.mapping.value]) }]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-waffle-" + layer.id).remove();
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/renderers/BeeswarmRenderer.js
+  var BeeswarmRenderer = class {
+    static type = "beeswarm";
+    static traits = {
+      hasAxes: true,
+      referenceLines: true,
+      legendType: "layer",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: { invertX: false }
+    };
+    static scaleHints = {
+      xScaleType: "linear",
+      yScaleType: "linear",
+      xExtentFields: ["x_var"],
+      yExtentFields: ["y_var"],
+      domainMerge: "union"
+    };
+    static dataContract = {
+      x_var: { required: true, numeric: true },
+      y_var: { required: true }
+    };
+    render(chart, layer) {
+      var xScale = chart.derived.xScale;
+      var yScale = chart.derived.yScale;
+      var radius = layer.options && layer.options.radius || 3;
+      var padding = layer.options && layer.options.padding || 1;
+      var xVar = layer.mapping.x_var;
+      var yVar = layer.mapping.y_var;
+      var data = layer.data.slice().sort(function(a, b) {
+        return xScale(a[xVar]) - xScale(b[xVar]);
+      });
+      var placed = [];
+      var diameter = 2 * radius + padding;
+      for (var i = 0; i < data.length; i++) {
+        var cx = xScale(data[i][xVar]);
+        var baseY = yScale(data[i][yVar]);
+        var dy = 0;
+        var found = false;
+        for (var attempt = 0; attempt < 500 && !found; attempt++) {
+          var candidateY = attempt === 0 ? baseY : attempt % 2 === 1 ? baseY + Math.ceil(attempt / 2) * diameter : baseY - Math.ceil(attempt / 2) * diameter;
+          var collision = false;
+          for (var j = 0; j < placed.length; j++) {
+            var dx2 = cx - placed[j].cx;
+            var dy2 = candidateY - placed[j].cy;
+            if (dx2 * dx2 + dy2 * dy2 < diameter * diameter) {
+              collision = true;
+              break;
+            }
+          }
+          if (!collision) {
+            dy = candidateY;
+            found = true;
+          }
+        }
+        data[i]._beeswarm_cx = cx;
+        data[i]._beeswarm_cy = dy;
+        placed.push({ cx, cy: dy });
+      }
+      var group = chart.dom.chartArea.selectAll(".tag-beeswarm-" + layer.id).data([null]).join("g").attr("class", "tag-beeswarm-" + layer.id);
+      group.selectAll(".beeswarm-point").data(data, function(d) {
+        return d._source_key;
+      }).join("circle").attr("class", "beeswarm-point").attr("cx", function(d) {
+        return d._beeswarm_cx;
+      }).attr("cy", function(d) {
+        return d._beeswarm_cy;
+      }).attr("r", radius).attr("fill", layer.color).attr("fill-opacity", 0.7);
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-beeswarm-" + layer.id + " .beeswarm-point";
+    }
+    formatTooltip(chart, d, layer) {
+      var yFormat = chart.runtime.activeYFormat || d3.format("s");
+      return {
+        title: { text: String(d[layer.mapping.x_var]) },
+        items: [{ color: layer.color, label: layer.label, value: yFormat(d[layer.mapping.y_var]) }]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-beeswarm-" + layer.id).remove();
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/renderers/BumpRenderer.js
+  var BumpRenderer = class {
+    static type = "bump";
+    static traits = {
+      hasAxes: true,
+      referenceLines: false,
+      legendType: "layer",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: {}
+    };
+    static scaleHints = {
+      xScaleType: "point",
+      yScaleType: "linear",
+      xExtentFields: [],
+      yExtentFields: ["y_var"],
+      domainMerge: "union"
+    };
+    static dataContract = {
+      x_var: { required: true },
+      y_var: { required: true, numeric: true },
+      group: { required: true }
+    };
+    render(chart, layer) {
+      var xScale = chart.derived.xScale;
+      var yScale = chart.derived.yScale;
+      var xVar = layer.mapping.x_var;
+      var yVar = layer.mapping.y_var;
+      var groupVar = layer.mapping.group;
+      var dotRadius = layer.options && layer.options.dotRadius || 5;
+      var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+      var groups = d3.group(layer.data, function(d) {
+        return d[groupVar];
+      });
+      var group = chart.dom.chartArea.selectAll(".tag-bump-" + layer.id).data([null]).join("g").attr("class", "tag-bump-" + layer.id);
+      var line = d3.line().x(function(d) {
+        return xScale(d[xVar]);
+      }).y(function(d) {
+        return yScale(d[yVar]);
+      }).curve(d3.curveBumpX);
+      var groupIndex = 0;
+      groups.forEach(function(data, name) {
+        var color = colorScale(name);
+        var sorted = data.slice().sort(function(a, b) {
+          return String(a[xVar]).localeCompare(String(b[xVar]));
+        });
+        group.selectAll(".bump-line-" + groupIndex).data([sorted]).join("path").attr("class", "bump-line bump-line-" + groupIndex).attr("d", line).attr("fill", "none").attr("stroke", color).attr("stroke-width", 2.5).attr("stroke-opacity", 0.8);
+        group.selectAll(".bump-dot-" + groupIndex).data(sorted).join("circle").attr("class", "bump-dot bump-dot-" + groupIndex).attr("cx", function(d) {
+          return xScale(d[xVar]);
+        }).attr("cy", function(d) {
+          return yScale(d[yVar]);
+        }).attr("r", dotRadius).attr("fill", color).attr("stroke", "#fff").attr("stroke-width", 1.5);
+        groupIndex++;
+      });
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-bump-" + layer.id + " .bump-dot";
+    }
+    formatTooltip(chart, d, layer) {
+      return {
+        title: { text: String(d[layer.mapping.group]) },
+        items: [
+          { color: layer.color, label: String(d[layer.mapping.x_var]), value: String(d[layer.mapping.y_var]) }
+        ]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-bump-" + layer.id).remove();
+    }
+  };
+
   // inst/htmlwidgets/myIO/src/registry.js
   var rendererRegistry = /* @__PURE__ */ new Map();
   function registerRenderer(type, RendererClass) {
@@ -2743,6 +2975,15 @@
     }
     if (!rendererRegistry.has(DumbbellRenderer.type)) {
       registerRenderer(DumbbellRenderer.type, new DumbbellRenderer());
+    }
+    if (!rendererRegistry.has(WaffleRenderer.type)) {
+      registerRenderer(WaffleRenderer.type, new WaffleRenderer());
+    }
+    if (!rendererRegistry.has(BeeswarmRenderer.type)) {
+      registerRenderer(BeeswarmRenderer.type, new BeeswarmRenderer());
+    }
+    if (!rendererRegistry.has(BumpRenderer.type)) {
+      registerRenderer(BumpRenderer.type, new BumpRenderer());
     }
     if (!rendererRegistry.has(TextRenderer.type)) {
       registerRenderer(TextRenderer.type, new TextRenderer());

--- a/inst/htmlwidgets/myIO/src/registry.js
+++ b/inst/htmlwidgets/myIO/src/registry.js
@@ -19,6 +19,9 @@ import { TextRenderer } from "./renderers/TextRenderer.js";
 import { BracketRenderer } from "./renderers/BracketRenderer.js";
 import { LollipopRenderer } from "./renderers/LollipopRenderer.js";
 import { DumbbellRenderer } from "./renderers/DumbbellRenderer.js";
+import { WaffleRenderer } from "./renderers/WaffleRenderer.js";
+import { BeeswarmRenderer } from "./renderers/BeeswarmRenderer.js";
+import { BumpRenderer } from "./renderers/BumpRenderer.js";
 
 export function registerRenderer(type, RendererClass) {
   if (rendererRegistry.has(type)) {
@@ -102,6 +105,15 @@ export function registerBuiltInRenderers() {
   }
   if (!rendererRegistry.has(DumbbellRenderer.type)) {
     registerRenderer(DumbbellRenderer.type, new DumbbellRenderer());
+  }
+  if (!rendererRegistry.has(WaffleRenderer.type)) {
+    registerRenderer(WaffleRenderer.type, new WaffleRenderer());
+  }
+  if (!rendererRegistry.has(BeeswarmRenderer.type)) {
+    registerRenderer(BeeswarmRenderer.type, new BeeswarmRenderer());
+  }
+  if (!rendererRegistry.has(BumpRenderer.type)) {
+    registerRenderer(BumpRenderer.type, new BumpRenderer());
   }
 
   if (!rendererRegistry.has(TextRenderer.type)) {

--- a/inst/htmlwidgets/myIO/src/renderers/BeeswarmRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/BeeswarmRenderer.js
@@ -1,0 +1,100 @@
+export class BeeswarmRenderer {
+  static type = "beeswarm";
+  static traits = {
+    hasAxes: true,
+    referenceLines: true,
+    legendType: "layer",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: { invertX: false }
+  };
+  static scaleHints = {
+    xScaleType: "linear",
+    yScaleType: "linear",
+    xExtentFields: ["x_var"],
+    yExtentFields: ["y_var"],
+    domainMerge: "union"
+  };
+  static dataContract = {
+    x_var: { required: true, numeric: true },
+    y_var: { required: true }
+  };
+
+  render(chart, layer) {
+    var xScale = chart.derived.xScale;
+    var yScale = chart.derived.yScale;
+    var radius = (layer.options && layer.options.radius) || 3;
+    var padding = (layer.options && layer.options.padding) || 1;
+    var xVar = layer.mapping.x_var;
+    var yVar = layer.mapping.y_var;
+
+    var data = layer.data.slice().sort(function(a, b) {
+      return xScale(a[xVar]) - xScale(b[xVar]);
+    });
+
+    var placed = [];
+    var diameter = 2 * radius + padding;
+
+    for (var i = 0; i < data.length; i++) {
+      var cx = xScale(data[i][xVar]);
+      var baseY = yScale(data[i][yVar]);
+      var dy = 0;
+      var found = false;
+
+      for (var attempt = 0; attempt < 500 && !found; attempt++) {
+        var candidateY = attempt === 0 ? baseY
+          : (attempt % 2 === 1
+            ? baseY + Math.ceil(attempt / 2) * diameter
+            : baseY - Math.ceil(attempt / 2) * diameter);
+
+        var collision = false;
+        for (var j = 0; j < placed.length; j++) {
+          var dx2 = cx - placed[j].cx;
+          var dy2 = candidateY - placed[j].cy;
+          if (dx2 * dx2 + dy2 * dy2 < diameter * diameter) {
+            collision = true;
+            break;
+          }
+        }
+
+        if (!collision) {
+          dy = candidateY;
+          found = true;
+        }
+      }
+
+      data[i]._beeswarm_cx = cx;
+      data[i]._beeswarm_cy = dy;
+      placed.push({ cx: cx, cy: dy });
+    }
+
+    var group = chart.dom.chartArea.selectAll(".tag-beeswarm-" + layer.id)
+      .data([null]).join("g").attr("class", "tag-beeswarm-" + layer.id);
+
+    group.selectAll(".beeswarm-point")
+      .data(data, function(d) { return d._source_key; })
+      .join("circle")
+      .attr("class", "beeswarm-point")
+      .attr("cx", function(d) { return d._beeswarm_cx; })
+      .attr("cy", function(d) { return d._beeswarm_cy; })
+      .attr("r", radius)
+      .attr("fill", layer.color)
+      .attr("fill-opacity", 0.7);
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-beeswarm-" + layer.id + " .beeswarm-point";
+  }
+
+  formatTooltip(chart, d, layer) {
+    var yFormat = chart.runtime.activeYFormat || d3.format("s");
+    return {
+      title: { text: String(d[layer.mapping.x_var]) },
+      items: [{ color: layer.color, label: layer.label, value: yFormat(d[layer.mapping.y_var]) }]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-beeswarm-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/src/renderers/BumpRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/BumpRenderer.js
@@ -1,0 +1,91 @@
+export class BumpRenderer {
+  static type = "bump";
+  static traits = {
+    hasAxes: true,
+    referenceLines: false,
+    legendType: "layer",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: {}
+  };
+  static scaleHints = {
+    xScaleType: "point",
+    yScaleType: "linear",
+    xExtentFields: [],
+    yExtentFields: ["y_var"],
+    domainMerge: "union"
+  };
+  static dataContract = {
+    x_var: { required: true },
+    y_var: { required: true, numeric: true },
+    group: { required: true }
+  };
+
+  render(chart, layer) {
+    var xScale = chart.derived.xScale;
+    var yScale = chart.derived.yScale;
+    var xVar = layer.mapping.x_var;
+    var yVar = layer.mapping.y_var;
+    var groupVar = layer.mapping.group;
+    var dotRadius = (layer.options && layer.options.dotRadius) || 5;
+    var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+
+    var groups = d3.group(layer.data, function(d) { return d[groupVar]; });
+
+    var group = chart.dom.chartArea.selectAll(".tag-bump-" + layer.id)
+      .data([null]).join("g").attr("class", "tag-bump-" + layer.id);
+
+    var line = d3.line()
+      .x(function(d) { return xScale(d[xVar]); })
+      .y(function(d) { return yScale(d[yVar]); })
+      .curve(d3.curveBumpX);
+
+    var groupIndex = 0;
+    groups.forEach(function(data, name) {
+      var color = colorScale(name);
+      var sorted = data.slice().sort(function(a, b) {
+        return String(a[xVar]).localeCompare(String(b[xVar]));
+      });
+
+      group.selectAll(".bump-line-" + groupIndex)
+        .data([sorted])
+        .join("path")
+        .attr("class", "bump-line bump-line-" + groupIndex)
+        .attr("d", line)
+        .attr("fill", "none")
+        .attr("stroke", color)
+        .attr("stroke-width", 2.5)
+        .attr("stroke-opacity", 0.8);
+
+      group.selectAll(".bump-dot-" + groupIndex)
+        .data(sorted)
+        .join("circle")
+        .attr("class", "bump-dot bump-dot-" + groupIndex)
+        .attr("cx", function(d) { return xScale(d[xVar]); })
+        .attr("cy", function(d) { return yScale(d[yVar]); })
+        .attr("r", dotRadius)
+        .attr("fill", color)
+        .attr("stroke", "#fff")
+        .attr("stroke-width", 1.5);
+
+      groupIndex++;
+    });
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-bump-" + layer.id + " .bump-dot";
+  }
+
+  formatTooltip(chart, d, layer) {
+    return {
+      title: { text: String(d[layer.mapping.group]) },
+      items: [
+        { color: layer.color, label: String(d[layer.mapping.x_var]), value: String(d[layer.mapping.y_var]) }
+      ]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-bump-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/src/renderers/WaffleRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/WaffleRenderer.js
@@ -1,0 +1,93 @@
+export class WaffleRenderer {
+  static type = "waffle";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "ordinal",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: {}
+  };
+  static scaleHints = null;
+  static dataContract = {
+    category: { required: true },
+    value: { required: true, numeric: true }
+  };
+
+  render(chart, layer) {
+    var rows = (layer.options && layer.options.rows) || 10;
+    var cols = (layer.options && layer.options.cols) || 10;
+    var totalCells = rows * cols;
+    var cellGap = (layer.options && layer.options.cellGap) || 2;
+    var cellRadius = (layer.options && layer.options.cellRadius) || 2;
+
+    var m = chart.config.layout.margin;
+    var chartWidth = chart.runtime.width - m.left - m.right;
+    var chartHeight = chart.runtime.height - m.top - m.bottom;
+    var cellSize = Math.min(
+      (chartWidth - (cols - 1) * cellGap) / cols,
+      (chartHeight - (rows - 1) * cellGap) / rows
+    );
+
+    var total = 0;
+    for (var i = 0; i < layer.data.length; i++) {
+      total += layer.data[i][layer.mapping.value];
+    }
+
+    var cells = [];
+    var cellIndex = 0;
+    var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+
+    for (var i = 0; i < layer.data.length; i++) {
+      var d = layer.data[i];
+      var count = Math.round((d[layer.mapping.value] / total) * totalCells);
+      for (var j = 0; j < count && cellIndex < totalCells; j++) {
+        cells.push({
+          category: d[layer.mapping.category],
+          row: Math.floor(cellIndex / cols),
+          col: cellIndex % cols,
+          color: colorScale(d[layer.mapping.category]),
+          datum: d,
+          _source_key: d._source_key
+        });
+        cellIndex++;
+      }
+    }
+
+    var gridWidth = cols * cellSize + (cols - 1) * cellGap;
+    var gridHeight = rows * cellSize + (rows - 1) * cellGap;
+    var offsetX = (chartWidth - gridWidth) / 2;
+    var offsetY = (chartHeight - gridHeight) / 2;
+
+    var group = chart.dom.chartArea.selectAll(".tag-waffle-" + layer.id)
+      .data([null]).join("g")
+      .attr("class", "tag-waffle-" + layer.id)
+      .attr("transform", "translate(" + offsetX + "," + offsetY + ")");
+
+    group.selectAll(".waffle-cell")
+      .data(cells)
+      .join("rect")
+      .attr("class", "waffle-cell")
+      .attr("x", function(d) { return d.col * (cellSize + cellGap); })
+      .attr("y", function(d) { return d.row * (cellSize + cellGap); })
+      .attr("width", cellSize)
+      .attr("height", cellSize)
+      .attr("rx", cellRadius)
+      .attr("fill", function(d) { return d.color; });
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-waffle-" + layer.id + " .waffle-cell";
+  }
+
+  formatTooltip(chart, d, layer) {
+    return {
+      title: { text: d.category },
+      items: [{ color: d.color, label: d.category, value: String(d.datum[layer.mapping.value]) }]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-waffle-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/style.css
+++ b/inst/htmlwidgets/myIO/style.css
@@ -782,3 +782,16 @@
 .dumbbell-line { shape-rendering: crispEdges; }
 .dumbbell-low, .dumbbell-high { cursor: pointer; transition: r 0.15s ease; }
 .dumbbell-low:hover, .dumbbell-high:hover { r: 7; }
+
+/* Waffle */
+.waffle-cell { cursor: pointer; transition: opacity 0.15s ease; }
+.waffle-cell:hover { opacity: 0.8; }
+
+/* Beeswarm */
+.beeswarm-point { cursor: pointer; transition: r 0.15s ease, fill-opacity 0.15s ease; }
+.beeswarm-point:hover { fill-opacity: 1; r: 5; }
+
+/* Bump */
+.bump-line { pointer-events: none; }
+.bump-dot { cursor: pointer; transition: r 0.15s ease; }
+.bump-dot:hover { r: 7; }

--- a/tests/testthat/test_beeswarm.R
+++ b/tests/testthat/test_beeswarm.R
@@ -1,0 +1,26 @@
+# Contract tests for beeswarm chart type (v1.2)
+
+test_that("beeswarm layer accepts valid inputs", {
+  p <- myIO(iris) |>
+    addIoLayer("beeswarm", label = "bs",
+               mapping = list(x_var = "Sepal.Length", y_var = "Species"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "beeswarm")
+})
+
+test_that("beeswarm rejects missing x_var", {
+  expect_error(
+    myIO(iris) |>
+      addIoLayer("beeswarm", label = "bs",
+                 mapping = list(y_var = "Species")),
+    "x_var"
+  )
+})
+
+test_that("beeswarm supports method option", {
+  p <- myIO(iris) |>
+    addIoLayer("beeswarm", label = "bs",
+               mapping = list(x_var = "Sepal.Length", y_var = "Species"),
+               options = list(method = "quasirandom"))
+  expect_equal(p$x$config$layers[[1]]$options$method, "quasirandom")
+})

--- a/tests/testthat/test_bump.R
+++ b/tests/testthat/test_bump.R
@@ -1,0 +1,35 @@
+# Contract tests for bump chart type (v1.2)
+
+test_that("bump layer accepts valid inputs", {
+  df <- data.frame(
+    time = rep(c("Q1", "Q2", "Q3"), each = 3),
+    rank = c(1, 2, 3, 2, 1, 3, 3, 2, 1),
+    team = rep(c("A", "B", "C"), 3)
+  )
+  p <- myIO(df) |>
+    addIoLayer("bump", label = "bmp",
+               mapping = list(x_var = "time", y_var = "rank", group = "team"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "bump")
+})
+
+test_that("bump rejects missing group", {
+  df <- data.frame(time = "Q1", rank = 1)
+  expect_error(
+    myIO(df) |>
+      addIoLayer("bump", label = "bmp",
+                 mapping = list(x_var = "time", y_var = "rank")),
+    "group"
+  )
+})
+
+test_that("bump rejects invalid transform", {
+  df <- data.frame(time = "Q1", rank = 1, team = "A")
+  expect_error(
+    myIO(df) |>
+      addIoLayer("bump", label = "bmp",
+                 mapping = list(x_var = "time", y_var = "rank", group = "team"),
+                 transform = "mean"),
+    "not valid"
+  )
+})

--- a/tests/testthat/test_waffle.R
+++ b/tests/testthat/test_waffle.R
@@ -1,0 +1,40 @@
+# Contract tests for waffle chart type (v1.2)
+
+test_that("waffle layer accepts valid inputs", {
+  df <- data.frame(cat = c("A", "B", "C"), val = c(50, 30, 20))
+  p <- myIO(df) |>
+    addIoLayer("waffle", label = "wf",
+               mapping = list(category = "cat", value = "val"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "waffle")
+})
+
+test_that("waffle rejects missing category", {
+  df <- data.frame(val = c(50, 30))
+  expect_error(
+    myIO(df) |>
+      addIoLayer("waffle", label = "wf",
+                 mapping = list(value = "val")),
+    "category"
+  )
+})
+
+test_that("waffle rejects missing value", {
+  df <- data.frame(cat = c("A", "B"))
+  expect_error(
+    myIO(df) |>
+      addIoLayer("waffle", label = "wf",
+                 mapping = list(category = "cat")),
+    "value"
+  )
+})
+
+test_that("waffle supports custom rows and cols", {
+  df <- data.frame(cat = c("A", "B"), val = c(60, 40))
+  p <- myIO(df) |>
+    addIoLayer("waffle", label = "wf",
+               mapping = list(category = "cat", value = "val"),
+               options = list(rows = 5, cols = 20))
+  expect_equal(p$x$config$layers[[1]]$options$rows, 5)
+  expect_equal(p$x$config$layers[[1]]$options$cols, 20)
+})


### PR DESCRIPTION
## Summary

- Completes all 5 new chart types from the v1.2 roadmap
- `waffle`: 10x10 grid of colored squares for proportions (standalone, configurable rows/cols)
- `beeswarm`: dodge-positioned points with inline collision detection algorithm (no external deps)
- `bump`: smooth S-curves via `d3.curveBumpX` for rank/value tracking over time (grouped)

## What changed

- **R infrastructure**: 3 new types in `ALLOWED_TYPES`, `COMPATIBILITY_GROUPS`, `VALID_COMBINATIONS`. Waffle gets `standalone-waffle` compat group. Bump requires `group` mapping
- **JS**: `WaffleRenderer`, `BeeswarmRenderer`, `BumpRenderer` — all with full renderer interface. Beeswarm uses an inline O(n^2) dodge that's sufficient for typical dataset sizes (<1000 points)
- **CSS**: Hover effects for waffle cells, beeswarm points, and bump dots

## Test plan

- [x] R tests: 723/723 pass (6 waffle + 4 beeswarm + 4 bump)
- [x] JS tests: 188/188 pass
- [x] Build: 232.4kb bundle
- [ ] Manual: waffle with 3-category proportional data
- [ ] Manual: beeswarm with iris Sepal.Length by Species
- [ ] Manual: bump chart with team rankings over quarters

🤖 Generated with [Claude Code](https://claude.com/claude-code)