### PR TITLE
Add SVG accessibility: ARIA roles, keyboard nav, data table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # myIO 1.2.0 (development)
 
+## SVG accessibility
+
+* ARIA roles (`graphics-document`, `graphics-object`, `graphics-symbol`) applied
+  to SVG chart structure for screen reader navigation.
+* Keyboard navigation: arrow keys traverse layers and data points, with live
+  region announcements (150ms debounce).
+* Hidden data table fallback for screen reader access to raw data (capped at
+  500 rows).
+* Focus ring styling and screen-reader-only utility class.
+
 ## New chart types
 
 * `lollipop` — vertical stem with circle head, supports `mean` and `summary`

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -4963,6 +4963,332 @@
     }
   };
 
+  // inst/htmlwidgets/myIO/src/a11y/descriptions.js
+  function generateChartLabel(config) {
+    var types = [];
+    var layers = config && config.layers || [];
+    for (var i = 0; i < layers.length; i++) {
+      var type = layers[i].type;
+      if (type && types.indexOf(type) === -1) {
+        types.push(type);
+      }
+    }
+    var xLabel = config && config.axes && config.axes.xAxisLabel || "x";
+    var yLabel = config && config.axes && config.axes.yAxisLabel || "y";
+    var prefix = types.length ? types.join(" and ") + " chart" : "chart";
+    return prefix + ": " + xLabel + " vs " + yLabel;
+  }
+  function generateLayerLabel(layer) {
+    var label = layer && (layer.label || layer.type) || "series";
+    var dataLength = layer && Array.isArray(layer.data) ? layer.data.length : 0;
+    return label + ": " + dataLength + " data points";
+  }
+  function generatePointLabel(d, layer) {
+    var mapping = layer && layer.mapping || {};
+    if (mapping.x_var && mapping.y_var && d) {
+      return String(d[mapping.x_var] != null ? d[mapping.x_var] : "") + ": " + String(d[mapping.y_var] != null ? d[mapping.y_var] : "");
+    }
+    if (mapping.category && mapping.value && d) {
+      return String(d[mapping.category] || "") + ": " + String(d[mapping.value] || "");
+    }
+    return "Data point";
+  }
+
+  // inst/htmlwidgets/myIO/src/a11y/aria.js
+  function sanitizeLabel(label) {
+    return String(label).replace(/[^a-zA-Z0-9_-]/g, "");
+  }
+  function getLayerGroup(chart, layer) {
+    if (!chart.dom || !chart.dom.chartArea || !layer) {
+      return null;
+    }
+    var chartArea = chart.dom.chartArea;
+    var selectors = [
+      ".tag-" + layer.type + "-" + layer.id,
+      ".tag-" + layer.type + "-" + chart.dom.element.id + "-" + sanitizeLabel(layer.label)
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      var selection = chartArea.select(selectors[i]);
+      if (!selection.empty()) {
+        return selection;
+      }
+    }
+    return null;
+  }
+  function getLayerElements(chart, layer) {
+    if (!chart.dom || !chart.dom.chartArea || !layer) {
+      return null;
+    }
+    var chartArea = chart.dom.chartArea;
+    var label = sanitizeLabel(layer.label);
+    var elementId = chart.dom.element.id;
+    var selectors = [];
+    if (layer.type === "line") {
+      selectors.push(".tag-point-" + elementId + "-" + label);
+    }
+    if (layer.type === "groupedBar") {
+      selectors.push(".tag-grouped-bar-g rect");
+    }
+    selectors.push(".tag-" + layer.type + "-" + elementId + "-" + label);
+    selectors.push(".tag-" + layer.type + "-" + layer.id + " circle");
+    selectors.push(".tag-" + layer.type + "-" + layer.id + " rect");
+    selectors.push(".tag-" + layer.type + "-" + layer.id + " path");
+    selectors.push(".tag-" + layer.type + "-" + layer.id + " line");
+    for (var i = 0; i < selectors.length; i++) {
+      var selection = chartArea.selectAll(selectors[i]);
+      if (!selection.empty()) {
+        return selection;
+      }
+    }
+    return null;
+  }
+  function applyARIA(chart) {
+    if (!chart || !chart.dom || !chart.dom.svg) {
+      return;
+    }
+    var svg = chart.dom.svg;
+    var layers = chart.config && chart.config.layers ? chart.config.layers : [];
+    svg.attr("role", "graphics-document").attr("aria-roledescription", "chart").attr("aria-label", generateChartLabel(chart.config)).attr("tabindex", "0");
+    if (chart.dom.chartArea) {
+      chart.dom.chartArea.attr("role", "graphics-object").attr("aria-roledescription", "plot area").attr("aria-label", "Plot area with " + layers.length + " data series");
+    }
+    for (var i = 0; i < layers.length; i++) {
+      var layer = layers[i];
+      var layerGroup = getLayerGroup(chart, layer);
+      var layerElements = getLayerElements(chart, layer);
+      if (layerGroup && !layerGroup.empty()) {
+        layerGroup.attr("role", "graphics-object").attr("aria-roledescription", layer.type + " series").attr("aria-label", generateLayerLabel(layer));
+      }
+      if (layerElements && !layerElements.empty()) {
+        layerElements.each(function(d) {
+          d3.select(this).attr("role", "graphics-symbol").attr("aria-roledescription", "data point").attr("aria-label", generatePointLabel(d, layer));
+        });
+      }
+    }
+  }
+
+  // inst/htmlwidgets/myIO/src/a11y/keyboard-nav.js
+  function sanitizeLabel2(label) {
+    return String(label).replace(/[^a-zA-Z0-9_-]/g, "");
+  }
+  function getLayerSymbols(chart, layer) {
+    if (!chart || !chart.dom || !chart.dom.chartArea || !layer) {
+      return d3.select(null);
+    }
+    var chartArea = chart.dom.chartArea;
+    var label = sanitizeLabel2(layer.label);
+    var elementId = chart.dom.element.id;
+    var selectors = [
+      ".tag-" + layer.type + "-" + layer.id + ' [role="graphics-symbol"]'
+    ];
+    if (layer.type === "line") {
+      selectors.push(".tag-point-" + elementId + "-" + label + '[role="graphics-symbol"]');
+    }
+    if (layer.type === "groupedBar") {
+      selectors.push('.tag-grouped-bar-g rect[role="graphics-symbol"]');
+    }
+    selectors.push(".tag-" + layer.type + "-" + elementId + "-" + label + '[role="graphics-symbol"]');
+    selectors.push(".tag-" + layer.type + "-" + layer.id + ' circle[role="graphics-symbol"]');
+    selectors.push(".tag-" + layer.type + "-" + layer.id + ' rect[role="graphics-symbol"]');
+    selectors.push(".tag-" + layer.type + "-" + layer.id + ' path[role="graphics-symbol"]');
+    selectors.push(".tag-" + layer.type + "-" + layer.id + ' line[role="graphics-symbol"]');
+    for (var i = 0; i < selectors.length; i++) {
+      var selection = chartArea.selectAll(selectors[i]);
+      if (!selection.empty()) {
+        return selection;
+      }
+    }
+    return d3.select(null);
+  }
+  var KeyboardNavigator = class {
+    constructor(chart) {
+      this.chart = chart;
+      this.state = "IDLE";
+      this.layerIndex = 0;
+      this.pointIndex = 0;
+      this.debounceTimer = null;
+      this.liveRegion = null;
+      this._keyHandler = null;
+    }
+    initialize() {
+      var self2 = this;
+      this.liveRegion = d3.select(this.chart.dom.element).append("div").attr("role", "status").attr("aria-live", "polite").attr("aria-atomic", "true").attr("class", "myIO-sr-only");
+      this._keyHandler = function(event) {
+        self2.handleKey(event);
+      };
+      this.chart.dom.svg.on("keydown.a11y", this._keyHandler);
+    }
+    handleKey(event) {
+      var key = event.key;
+      switch (key) {
+        case "ArrowRight":
+          event.preventDefault();
+          this.movePoint(1);
+          break;
+        case "ArrowLeft":
+          event.preventDefault();
+          this.movePoint(-1);
+          break;
+        case "ArrowDown":
+          event.preventDefault();
+          this.moveLayer(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          this.moveLayer(-1);
+          break;
+        case "Escape":
+          event.preventDefault();
+          this.reset();
+          break;
+      }
+    }
+    movePoint(delta) {
+      var layers = this.getNavigableLayers();
+      if (!layers.length) {
+        return;
+      }
+      if (this.state === "IDLE") {
+        this.state = "POINT";
+        this.layerIndex = 0;
+        this.pointIndex = 0;
+      } else {
+        var maxIndex = layers[this.layerIndex].data.length - 1;
+        this.pointIndex = Math.max(0, Math.min(maxIndex, this.pointIndex + delta));
+      }
+      this.focusCurrent();
+    }
+    moveLayer(delta) {
+      var layers = this.getNavigableLayers();
+      if (!layers.length) {
+        return;
+      }
+      var maxIndex = layers.length - 1;
+      this.layerIndex = Math.max(0, Math.min(maxIndex, this.layerIndex + delta));
+      this.pointIndex = 0;
+      this.state = "POINT";
+      this.focusCurrent();
+    }
+    focusCurrent() {
+      var layers = this.getNavigableLayers();
+      var layer = layers[this.layerIndex];
+      if (!layer || !layer.data || !layer.data.length) {
+        return;
+      }
+      var d = layer.data[this.pointIndex];
+      if (!d) {
+        return;
+      }
+      this.chart.dom.chartArea.selectAll(".myIO-kb-focus").classed("myIO-kb-focus", false);
+      var elements = getLayerSymbols(this.chart, layer);
+      var pointIndex = this.pointIndex;
+      var target = elements.filter(function(dd, i) {
+        if (dd && d && dd._source_key != null && d._source_key != null) {
+          return dd._source_key === d._source_key;
+        }
+        return dd === d || i === pointIndex;
+      });
+      if (!target.empty()) {
+        target.classed("myIO-kb-focus", true);
+      }
+      var mapping = layer.mapping || {};
+      var text = "";
+      if (mapping.x_var && mapping.y_var && d) {
+        text = String(d[mapping.x_var]) + ": " + String(d[mapping.y_var]);
+      } else {
+        text = "Point " + (this.pointIndex + 1) + " of " + layer.data.length;
+      }
+      this.announce(text);
+    }
+    announce(text) {
+      var self2 = this;
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = setTimeout(function() {
+        if (self2.liveRegion) {
+          self2.liveRegion.text(text);
+        }
+      }, 150);
+    }
+    reset() {
+      this.state = "IDLE";
+      this.chart.dom.chartArea.selectAll(".myIO-kb-focus").classed("myIO-kb-focus", false);
+      if (this.liveRegion) {
+        this.liveRegion.text("");
+      }
+    }
+    getNavigableLayers() {
+      return this.chart.config.layers.filter(function(layer) {
+        return layer.data && layer.data.length > 0 && layer.visibility !== false;
+      });
+    }
+    destroy() {
+      this.chart.dom.svg.on("keydown.a11y", null);
+      if (this.liveRegion) {
+        this.liveRegion.remove();
+      }
+      clearTimeout(this.debounceTimer);
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/a11y/data-table.js
+  var DataTableFallback = class {
+    constructor(chart) {
+      this.chart = chart;
+      this.tableContainer = null;
+      this.visible = false;
+    }
+    initialize() {
+      this.tableContainer = d3.select(this.chart.dom.element).append("div").attr("class", "myIO-data-table myIO-sr-only").attr("role", "region").attr("aria-label", "Chart data table");
+    }
+    generate() {
+      if (!this.tableContainer) {
+        return;
+      }
+      this.tableContainer.selectAll("*").remove();
+      var layers = this.chart.config.layers;
+      var maxRows = 500;
+      for (var i = 0; i < layers.length; i++) {
+        var layer = layers[i];
+        var data = Array.isArray(layer.data) ? layer.data : [];
+        var display = data.slice(0, maxRows);
+        var columns = Object.values(layer.mapping || {}).filter(Boolean);
+        var table = this.tableContainer.append("table").attr("aria-label", "Data for " + (layer.label || layer.type));
+        var thead = table.append("thead");
+        var headerRow = thead.append("tr");
+        for (var c = 0; c < columns.length; c++) {
+          headerRow.append("th").attr("scope", "col").text(columns[c]);
+        }
+        var tbody = table.append("tbody");
+        for (var r = 0; r < display.length; r++) {
+          var row = tbody.append("tr");
+          for (var c2 = 0; c2 < columns.length; c2++) {
+            var value = display[r][columns[c2]];
+            row.append("td").text(value != null ? String(value) : "");
+          }
+        }
+        if (data.length > maxRows) {
+          this.tableContainer.append("p").text("Showing first " + maxRows + " of " + data.length + " rows");
+        }
+      }
+    }
+    toggle() {
+      this.visible = !this.visible;
+      if (this.visible) {
+        this.generate();
+        this.tableContainer.classed("myIO-sr-only", false);
+        this.chart.dom.svg.attr("aria-hidden", "true");
+      } else {
+        this.tableContainer.classed("myIO-sr-only", true);
+        this.chart.dom.svg.attr("aria-hidden", null);
+      }
+    }
+    destroy() {
+      if (this.tableContainer) {
+        this.tableContainer.remove();
+      }
+    }
+  };
+
   // inst/htmlwidgets/myIO/src/Chart.js
   var MIN_CHART_WIDTH = 280;
   var RESIZE_DEBOUNCE_MS = 100;
@@ -5111,6 +5437,13 @@
       this.themeManager = new ThemeManager(this.dom.element, this.config);
       this.themeManager.initialize();
       initializeTooltip(this);
+      if (!this.config.sparkline) {
+        this.keyboardNav = new KeyboardNavigator(this);
+        this.keyboardNav.initialize();
+        this.dataTable = new DataTableFallback(this);
+        this.dataTable.initialize();
+        applyARIA(this);
+      }
       this.captureLegacyAliases();
       if (this.derived.currentLayers.length > 0) {
         this.setClipPath(this.derived.currentLayers[0].type);
@@ -5169,6 +5502,9 @@
         }
         if (this.derived.currentLayers.length === 0) {
           this.renderEmptyState();
+          if (!this.config.sparkline) {
+            applyARIA(this);
+          }
           return;
         }
         const state = deriveChartRender(this);
@@ -5198,6 +5534,9 @@
           bindSliders(this);
         }
         this.emit("afterRender", { state });
+        if (!this.config.sparkline) {
+          applyARIA(this);
+        }
       } catch (error) {
         console.warn("[myIO] Render error:", error.message);
         this.emit("error", { message: error.message, error });
@@ -5374,6 +5713,8 @@
         this.facetController.destroy();
         this.facetController = null;
       }
+      if (this.keyboardNav) this.keyboardNav.destroy();
+      if (this.dataTable) this.dataTable.destroy();
       if (this.themeManager) {
         this.themeManager.destroy();
       }

--- a/inst/htmlwidgets/myIO/src/Chart.js
+++ b/inst/htmlwidgets/myIO/src/Chart.js
@@ -18,6 +18,9 @@ import { linearRegression } from "./utils/math.js";
 import { tagName } from "./utils/responsive.js";
 import { ThemeManager } from "./theme/theme-manager.js";
 import { FacetController } from "./layout/facet-controller.js";
+import { applyARIA } from "./a11y/aria.js";
+import { KeyboardNavigator } from "./a11y/keyboard-nav.js";
+import { DataTableFallback } from "./a11y/data-table.js";
 
 const MIN_CHART_WIDTH = 280;
 const RESIZE_DEBOUNCE_MS = 100;
@@ -178,6 +181,13 @@ export class myIOchart {
     this.themeManager = new ThemeManager(this.dom.element, this.config);
     this.themeManager.initialize();
     initializeTooltip(this);
+    if (!this.config.sparkline) {
+      this.keyboardNav = new KeyboardNavigator(this);
+      this.keyboardNav.initialize();
+      this.dataTable = new DataTableFallback(this);
+      this.dataTable.initialize();
+      applyARIA(this);
+    }
     this.captureLegacyAliases();
     if (this.derived.currentLayers.length > 0) {
       this.setClipPath(this.derived.currentLayers[0].type);
@@ -240,6 +250,9 @@ export class myIOchart {
       }
       if (this.derived.currentLayers.length === 0) {
         this.renderEmptyState();
+        if (!this.config.sparkline) {
+          applyARIA(this);
+        }
         return;
       }
       const state = deriveChartRender(this);
@@ -269,6 +282,9 @@ export class myIOchart {
         bindSliders(this);
       }
       this.emit("afterRender", { state });
+      if (!this.config.sparkline) {
+        applyARIA(this);
+      }
     } catch (error) {
       console.warn("[myIO] Render error:", error.message);
       this.emit("error", { message: error.message, error });
@@ -469,6 +485,8 @@ export class myIOchart {
       this.facetController.destroy();
       this.facetController = null;
     }
+    if (this.keyboardNav) this.keyboardNav.destroy();
+    if (this.dataTable) this.dataTable.destroy();
     if (this.themeManager) {
       this.themeManager.destroy();
     }

--- a/inst/htmlwidgets/myIO/src/a11y/aria.js
+++ b/inst/htmlwidgets/myIO/src/a11y/aria.js
@@ -1,0 +1,103 @@
+import { generateChartLabel, generateLayerLabel, generatePointLabel } from "./descriptions.js";
+
+function sanitizeLabel(label) {
+  return String(label).replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
+function getLayerGroup(chart, layer) {
+  if (!chart.dom || !chart.dom.chartArea || !layer) {
+    return null;
+  }
+
+  var chartArea = chart.dom.chartArea;
+  var selectors = [
+    ".tag-" + layer.type + "-" + layer.id,
+    ".tag-" + layer.type + "-" + chart.dom.element.id + "-" + sanitizeLabel(layer.label)
+  ];
+
+  for (var i = 0; i < selectors.length; i++) {
+    var selection = chartArea.select(selectors[i]);
+    if (!selection.empty()) {
+      return selection;
+    }
+  }
+
+  return null;
+}
+
+function getLayerElements(chart, layer) {
+  if (!chart.dom || !chart.dom.chartArea || !layer) {
+    return null;
+  }
+
+  var chartArea = chart.dom.chartArea;
+  var label = sanitizeLabel(layer.label);
+  var elementId = chart.dom.element.id;
+  var selectors = [];
+
+  if (layer.type === "line") {
+    selectors.push(".tag-point-" + elementId + "-" + label);
+  }
+
+  if (layer.type === "groupedBar") {
+    selectors.push(".tag-grouped-bar-g rect");
+  }
+
+  selectors.push(".tag-" + layer.type + "-" + elementId + "-" + label);
+  selectors.push(".tag-" + layer.type + "-" + layer.id + " circle");
+  selectors.push(".tag-" + layer.type + "-" + layer.id + " rect");
+  selectors.push(".tag-" + layer.type + "-" + layer.id + " path");
+  selectors.push(".tag-" + layer.type + "-" + layer.id + " line");
+
+  for (var i = 0; i < selectors.length; i++) {
+    var selection = chartArea.selectAll(selectors[i]);
+    if (!selection.empty()) {
+      return selection;
+    }
+  }
+
+  return null;
+}
+
+export function applyARIA(chart) {
+  if (!chart || !chart.dom || !chart.dom.svg) {
+    return;
+  }
+
+  var svg = chart.dom.svg;
+  var layers = chart.config && chart.config.layers ? chart.config.layers : [];
+
+  svg.attr("role", "graphics-document")
+    .attr("aria-roledescription", "chart")
+    .attr("aria-label", generateChartLabel(chart.config))
+    .attr("tabindex", "0");
+
+  if (chart.dom.chartArea) {
+    chart.dom.chartArea
+      .attr("role", "graphics-object")
+      .attr("aria-roledescription", "plot area")
+      .attr("aria-label", "Plot area with " + layers.length + " data series");
+  }
+
+  for (var i = 0; i < layers.length; i++) {
+    var layer = layers[i];
+    var layerGroup = getLayerGroup(chart, layer);
+    var layerElements = getLayerElements(chart, layer);
+
+    if (layerGroup && !layerGroup.empty()) {
+      layerGroup
+        .attr("role", "graphics-object")
+        .attr("aria-roledescription", layer.type + " series")
+        .attr("aria-label", generateLayerLabel(layer));
+    }
+
+    if (layerElements && !layerElements.empty()) {
+      layerElements.each(function(d) {
+        d3.select(this)
+          .attr("role", "graphics-symbol")
+          .attr("aria-roledescription", "data point")
+          .attr("aria-label", generatePointLabel(d, layer));
+      });
+    }
+  }
+}

--- a/inst/htmlwidgets/myIO/src/a11y/data-table.js
+++ b/inst/htmlwidgets/myIO/src/a11y/data-table.js
@@ -1,0 +1,75 @@
+export class DataTableFallback {
+  constructor(chart) {
+    this.chart = chart;
+    this.tableContainer = null;
+    this.visible = false;
+  }
+
+  initialize() {
+    this.tableContainer = d3.select(this.chart.dom.element)
+      .append("div")
+      .attr("class", "myIO-data-table myIO-sr-only")
+      .attr("role", "region")
+      .attr("aria-label", "Chart data table");
+  }
+
+  generate() {
+    if (!this.tableContainer) {
+      return;
+    }
+
+    this.tableContainer.selectAll("*").remove();
+
+    var layers = this.chart.config.layers;
+    var maxRows = 500;
+
+    for (var i = 0; i < layers.length; i++) {
+      var layer = layers[i];
+      var data = Array.isArray(layer.data) ? layer.data : [];
+      var display = data.slice(0, maxRows);
+      var columns = Object.values(layer.mapping || {}).filter(Boolean);
+
+      var table = this.tableContainer.append("table")
+        .attr("aria-label", "Data for " + (layer.label || layer.type));
+
+      var thead = table.append("thead");
+      var headerRow = thead.append("tr");
+      for (var c = 0; c < columns.length; c++) {
+        headerRow.append("th").attr("scope", "col").text(columns[c]);
+      }
+
+      var tbody = table.append("tbody");
+      for (var r = 0; r < display.length; r++) {
+        var row = tbody.append("tr");
+        for (var c2 = 0; c2 < columns.length; c2++) {
+          var value = display[r][columns[c2]];
+          row.append("td").text(value != null ? String(value) : "");
+        }
+      }
+
+      if (data.length > maxRows) {
+        this.tableContainer.append("p")
+          .text("Showing first " + maxRows + " of " + data.length + " rows");
+      }
+    }
+  }
+
+  toggle() {
+    this.visible = !this.visible;
+
+    if (this.visible) {
+      this.generate();
+      this.tableContainer.classed("myIO-sr-only", false);
+      this.chart.dom.svg.attr("aria-hidden", "true");
+    } else {
+      this.tableContainer.classed("myIO-sr-only", true);
+      this.chart.dom.svg.attr("aria-hidden", null);
+    }
+  }
+
+  destroy() {
+    if (this.tableContainer) {
+      this.tableContainer.remove();
+    }
+  }
+}

--- a/inst/htmlwidgets/myIO/src/a11y/descriptions.js
+++ b/inst/htmlwidgets/myIO/src/a11y/descriptions.js
@@ -1,0 +1,39 @@
+export function generateChartLabel(config) {
+  var types = [];
+  var layers = (config && config.layers) || [];
+
+  for (var i = 0; i < layers.length; i++) {
+    var type = layers[i].type;
+    if (type && types.indexOf(type) === -1) {
+      types.push(type);
+    }
+  }
+
+  var xLabel = (config && config.axes && config.axes.xAxisLabel) || "x";
+  var yLabel = (config && config.axes && config.axes.yAxisLabel) || "y";
+  var prefix = types.length ? types.join(" and ") + " chart" : "chart";
+
+  return prefix + ": " + xLabel + " vs " + yLabel;
+}
+
+export function generateLayerLabel(layer) {
+  var label = (layer && (layer.label || layer.type)) || "series";
+  var dataLength = layer && Array.isArray(layer.data) ? layer.data.length : 0;
+
+  return label + ": " + dataLength + " data points";
+}
+
+export function generatePointLabel(d, layer) {
+  var mapping = (layer && layer.mapping) || {};
+
+  if (mapping.x_var && mapping.y_var && d) {
+    return String(d[mapping.x_var] != null ? d[mapping.x_var] : "") + ": "
+      + String(d[mapping.y_var] != null ? d[mapping.y_var] : "");
+  }
+
+  if (mapping.category && mapping.value && d) {
+    return String(d[mapping.category] || "") + ": " + String(d[mapping.value] || "");
+  }
+
+  return "Data point";
+}

--- a/inst/htmlwidgets/myIO/src/a11y/keyboard-nav.js
+++ b/inst/htmlwidgets/myIO/src/a11y/keyboard-nav.js
@@ -1,0 +1,201 @@
+function sanitizeLabel(label) {
+  return String(label).replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
+function getLayerSymbols(chart, layer) {
+  if (!chart || !chart.dom || !chart.dom.chartArea || !layer) {
+    return d3.select(null);
+  }
+
+  var chartArea = chart.dom.chartArea;
+  var label = sanitizeLabel(layer.label);
+  var elementId = chart.dom.element.id;
+  var selectors = [
+    ".tag-" + layer.type + "-" + layer.id + ' [role="graphics-symbol"]'
+  ];
+
+  if (layer.type === "line") {
+    selectors.push('.tag-point-' + elementId + "-" + label + '[role="graphics-symbol"]');
+  }
+
+  if (layer.type === "groupedBar") {
+    selectors.push('.tag-grouped-bar-g rect[role="graphics-symbol"]');
+  }
+
+  selectors.push('.tag-' + layer.type + "-" + elementId + "-" + label + '[role="graphics-symbol"]');
+  selectors.push('.tag-' + layer.type + "-" + layer.id + ' circle[role="graphics-symbol"]');
+  selectors.push('.tag-' + layer.type + "-" + layer.id + ' rect[role="graphics-symbol"]');
+  selectors.push('.tag-' + layer.type + "-" + layer.id + ' path[role="graphics-symbol"]');
+  selectors.push('.tag-' + layer.type + "-" + layer.id + ' line[role="graphics-symbol"]');
+
+  for (var i = 0; i < selectors.length; i++) {
+    var selection = chartArea.selectAll(selectors[i]);
+    if (!selection.empty()) {
+      return selection;
+    }
+  }
+
+  return d3.select(null);
+}
+
+export class KeyboardNavigator {
+  constructor(chart) {
+    this.chart = chart;
+    this.state = "IDLE";
+    this.layerIndex = 0;
+    this.pointIndex = 0;
+    this.debounceTimer = null;
+    this.liveRegion = null;
+    this._keyHandler = null;
+  }
+
+  initialize() {
+    var self = this;
+
+    this.liveRegion = d3.select(this.chart.dom.element)
+      .append("div")
+      .attr("role", "status")
+      .attr("aria-live", "polite")
+      .attr("aria-atomic", "true")
+      .attr("class", "myIO-sr-only");
+
+    this._keyHandler = function(event) { self.handleKey(event); };
+    this.chart.dom.svg.on("keydown.a11y", this._keyHandler);
+  }
+
+  handleKey(event) {
+    var key = event.key;
+
+    switch (key) {
+      case "ArrowRight":
+        event.preventDefault();
+        this.movePoint(1);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        this.movePoint(-1);
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        this.moveLayer(1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        this.moveLayer(-1);
+        break;
+      case "Escape":
+        event.preventDefault();
+        this.reset();
+        break;
+    }
+  }
+
+  movePoint(delta) {
+    var layers = this.getNavigableLayers();
+    if (!layers.length) {
+      return;
+    }
+
+    if (this.state === "IDLE") {
+      this.state = "POINT";
+      this.layerIndex = 0;
+      this.pointIndex = 0;
+    } else {
+      var maxIndex = layers[this.layerIndex].data.length - 1;
+      this.pointIndex = Math.max(0, Math.min(maxIndex, this.pointIndex + delta));
+    }
+
+    this.focusCurrent();
+  }
+
+  moveLayer(delta) {
+    var layers = this.getNavigableLayers();
+    if (!layers.length) {
+      return;
+    }
+
+    var maxIndex = layers.length - 1;
+    this.layerIndex = Math.max(0, Math.min(maxIndex, this.layerIndex + delta));
+    this.pointIndex = 0;
+    this.state = "POINT";
+    this.focusCurrent();
+  }
+
+  focusCurrent() {
+    var layers = this.getNavigableLayers();
+    var layer = layers[this.layerIndex];
+
+    if (!layer || !layer.data || !layer.data.length) {
+      return;
+    }
+
+    var d = layer.data[this.pointIndex];
+    if (!d) {
+      return;
+    }
+
+    this.chart.dom.chartArea.selectAll(".myIO-kb-focus")
+      .classed("myIO-kb-focus", false);
+
+    var elements = getLayerSymbols(this.chart, layer);
+    var pointIndex = this.pointIndex;
+    var target = elements.filter(function(dd, i) {
+      if (dd && d && dd._source_key != null && d._source_key != null) {
+        return dd._source_key === d._source_key;
+      }
+      return dd === d || i === pointIndex;
+    });
+
+    if (!target.empty()) {
+      target.classed("myIO-kb-focus", true);
+    }
+
+    var mapping = layer.mapping || {};
+    var text = "";
+
+    if (mapping.x_var && mapping.y_var && d) {
+      text = String(d[mapping.x_var]) + ": " + String(d[mapping.y_var]);
+    } else {
+      text = "Point " + (this.pointIndex + 1) + " of " + layer.data.length;
+    }
+
+    this.announce(text);
+  }
+
+  announce(text) {
+    var self = this;
+
+    clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(function() {
+      if (self.liveRegion) {
+        self.liveRegion.text(text);
+      }
+    }, 150);
+  }
+
+  reset() {
+    this.state = "IDLE";
+    this.chart.dom.chartArea.selectAll(".myIO-kb-focus")
+      .classed("myIO-kb-focus", false);
+
+    if (this.liveRegion) {
+      this.liveRegion.text("");
+    }
+  }
+
+  getNavigableLayers() {
+    return this.chart.config.layers.filter(function(layer) {
+      return layer.data && layer.data.length > 0 && layer.visibility !== false;
+    });
+  }
+
+  destroy() {
+    this.chart.dom.svg.on("keydown.a11y", null);
+
+    if (this.liveRegion) {
+      this.liveRegion.remove();
+    }
+
+    clearTimeout(this.debounceTimer);
+  }
+}

--- a/inst/htmlwidgets/myIO/style.css
+++ b/inst/htmlwidgets/myIO/style.css
@@ -795,3 +795,42 @@
 .bump-line { pointer-events: none; }
 .bump-dot { cursor: pointer; transition: r 0.15s ease; }
 .bump-dot:hover { r: 7; }
+
+/* Keyboard focus ring on data points */
+.myIO-kb-focus {
+  outline: none;
+  stroke: rgba(59, 130, 246, 0.8) !important;
+  stroke-width: 3 !important;
+}
+
+/* Screen reader only */
+.myIO-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Data table (visible when toggled) */
+.myIO-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--chart-font, system-ui);
+  font-size: 12px;
+}
+
+.myIO-data-table th, .myIO-data-table td {
+  padding: 4px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--chart-grid-color, #e5e7eb);
+}
+
+.myIO-data-table th {
+  font-weight: 600;
+  color: var(--chart-text-color);
+}

--- a/tests/js/a11y.test.js
+++ b/tests/js/a11y.test.js
@@ -1,0 +1,83 @@
+import * as d3 from "d3";
+import { beforeEach, describe, expect, test } from "vitest";
+import { myIOchart } from "../../inst/htmlwidgets/myIO/src/Chart.js";
+import { registerBuiltInRenderers } from "../../inst/htmlwidgets/myIO/src/registry.js";
+
+globalThis.d3 = d3;
+globalThis.HTMLWidgets = { shinyMode: false };
+
+function chartWithData() {
+  return new myIOchart({
+    element: document.getElementById("chart"),
+    width: 640,
+    height: 400,
+    config: {
+      specVersion: 1,
+      layers: [{
+        id: "layer_001", type: "point", label: "iris",
+        data: [
+          { sl: 5.1, sw: 3.5, _source_key: "k1" },
+          { sl: 4.9, sw: 3.0, _source_key: "k2" },
+          { sl: 4.7, sw: 3.2, _source_key: "k3" }
+        ],
+        mapping: { x_var: "sl", y_var: "sw" },
+        options: {}, transform: "identity", transformMeta: {},
+        encoding: {}, sourceKey: "_source_key", derivedFrom: null,
+        order: 1, visibility: true, color: "#E69F00"
+      }],
+      layout: { margin: { top: 30, bottom: 60, left: 50, right: 5 }, suppressLegend: false, suppressAxis: { xAxis: false, yAxis: false } },
+      scales: { xlim: { min: null, max: null }, ylim: { min: null, max: null }, categoricalScale: { xAxis: false, yAxis: false }, flipAxis: false, colorScheme: { colors: ["#E69F00"], domain: ["none"], enabled: false } },
+      axes: { xAxisFormat: "s", yAxisFormat: "s", xAxisLabel: "Sepal Length", yAxisLabel: "Sepal Width", toolTipFormat: "s" },
+      interactions: { dragPoints: false, toggleY: { variable: null, format: null }, toolTipOptions: { suppressY: false } },
+      theme: {},
+      transitions: { speed: 0 },
+      referenceLines: { x: null, y: null }
+    }
+  });
+}
+
+describe("Accessibility", function() {
+  beforeEach(function() {
+    document.body.innerHTML = "<div id='chart'></div>";
+    registerBuiltInRenderers();
+  });
+
+  test("SVG has role graphics-document", function() {
+    var chart = chartWithData();
+    var svg = document.querySelector("#chart svg");
+    expect(svg.getAttribute("role")).toBe("graphics-document");
+  });
+
+  test("SVG has aria-roledescription chart", function() {
+    var chart = chartWithData();
+    var svg = document.querySelector("#chart svg");
+    expect(svg.getAttribute("aria-roledescription")).toBe("chart");
+  });
+
+  test("SVG has aria-label with axis info", function() {
+    var chart = chartWithData();
+    var svg = document.querySelector("#chart svg");
+    var label = svg.getAttribute("aria-label");
+    expect(label).toContain("chart");
+  });
+
+  test("SVG is focusable via tabindex", function() {
+    var chart = chartWithData();
+    var svg = document.querySelector("#chart svg");
+    expect(svg.getAttribute("tabindex")).toBe("0");
+  });
+
+  test("chart area has role graphics-object", function() {
+    var chart = chartWithData();
+    var chartArea = document.querySelector("#chart .myIO-chart-area");
+    if (chartArea) {
+      expect(chartArea.getAttribute("role")).toBe("graphics-object");
+    }
+  });
+
+  test("screen reader only class exists in DOM", function() {
+    var chart = chartWithData();
+    var srOnly = document.querySelector("#chart .myIO-sr-only");
+    expect(srOnly).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- ARIA roles (`graphics-document`, `graphics-object`, `graphics-symbol`) applied to SVG chart structure after each render cycle
- Keyboard navigation: arrow keys traverse layers and data points with live region announcements (150ms debounce)
- Hidden data table fallback for screen reader access to raw chart data (capped at 500 rows)
- Focus ring styling and `.myIO-sr-only` utility class

## What changed

- **JS modules**: `a11y/aria.js` (role assignment), `a11y/descriptions.js` (auto-label generators), `a11y/keyboard-nav.js` (state machine), `a11y/data-table.js` (hidden table)
- **Chart.js**: Initializes keyboard nav + data table in `initialize()`, applies ARIA after `renderCurrentLayers()`, cleans up in `destroy()`. All skipped in sparkline mode
- **CSS**: Focus ring, screen-reader-only class, data table styles

## Test plan

- [x] JS tests: 194/194 pass (6 new a11y tests)
- [x] R tests: 723/723 pass (unchanged)
- [x] Build: 244.4kb bundle
- [ ] Manual: Tab into chart, verify screen reader announcement
- [ ] Manual: Arrow keys navigate points
- [ ] Manual: VoiceOver on macOS reads chart description

🤖 Generated with [Claude Code](https://claude.com/claude-code)