### PR TITLE
Add radar, funnel, and parallel coordinates chart types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@
 * `waffle` — 10x10 grid of colored squares representing proportions. Standalone.
 * `beeswarm` — dodge-positioned points to avoid overlap. Inline dodge algorithm.
 * `bump` — smooth S-curves showing rank/value changes over time with grouped lines.
+* `radar` — spider/radar chart with radial axes and polygon data fill.
+* `funnel` — narrowing horizontal bars for conversion pipeline data.
+* `parallel` — parallel coordinates for multivariate exploration.
   All new types support themed colors and standard tooltip formatting.
 
 ## Small multiples / faceting

--- a/R/addIoLayer.R
+++ b/R/addIoLayer.R
@@ -223,6 +223,9 @@ validate_layer_inputs <- function(type, transform, mapping, label, data, existin
       dumbbell = c("x_var", "low_y", "high_y"),
       waffle = c("category", "value"),
       bump = c("x_var", "y_var", "group"),
+      radar = c("axis", "value"),
+      funnel = c("stage", "value"),
+      parallel = c("dimensions"),
       c("x_var", "y_var")
     )
   }

--- a/R/util.R
+++ b/R/util.R
@@ -32,6 +32,7 @@ ALLOWED_TYPES <- c(
   "comparison", "qq",
   "lollipop", "dumbbell",
   "waffle", "beeswarm", "bump",
+  "radar", "funnel", "parallel",
   "survfit", "histogram_fit"
 )
 
@@ -64,6 +65,9 @@ COMPATIBILITY_GROUPS <- list(
   waffle = "standalone-waffle",
   beeswarm = "axes-continuous",
   bump = "axes-continuous",
+  radar = "standalone-radar",
+  funnel = "standalone-funnel",
+  parallel = "standalone-parallel",
   survfit = "axes-continuous",
   histogram_fit = "axes-binned"
 )
@@ -78,7 +82,10 @@ GROUP_MATRIX <- list(
   "standalone-treemap" = c("standalone-treemap"),
   "standalone-donut" = c("standalone-donut"),
   "standalone-gauge" = c("standalone-gauge"),
-  "standalone-waffle" = c("standalone-waffle")
+  "standalone-waffle" = c("standalone-waffle"),
+  "standalone-radar" = c("standalone-radar"),
+  "standalone-funnel" = c("standalone-funnel"),
+  "standalone-parallel" = c("standalone-parallel")
 )
 
 VALID_COMBINATIONS <- list(
@@ -107,6 +114,9 @@ VALID_COMBINATIONS <- list(
   waffle = c("identity"),
   beeswarm = c("identity"),
   bump = c("identity"),
+  radar = c("identity"),
+  funnel = c("identity"),
+  parallel = c("identity"),
   survfit = c("identity"),
   histogram_fit = c("identity")
 )

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -946,6 +946,18 @@
       keys = layer.data.map(function(d) {
         return d[layer.mapping.x_var];
       });
+    } else if (layer.type === "funnel" && Array.isArray(layer.data)) {
+      keys = layer.data.map(function(d) {
+        return d[layer.mapping.stage];
+      });
+    } else if (layer.type === "radar" && Array.isArray(layer.data)) {
+      keys = layer.mapping.group ? Array.from(new Set(layer.data.map(function(d) {
+        return d[layer.mapping.group];
+      }))) : [layer.label];
+    } else if (layer.type === "parallel" && Array.isArray(layer.data)) {
+      keys = layer.mapping.group ? Array.from(new Set(layer.data.map(function(d) {
+        return d[layer.mapping.group];
+      }))) : [layer.label];
     }
     return {
       type: "ordinal",
@@ -2897,6 +2909,344 @@
     }
   };
 
+  // inst/htmlwidgets/myIO/src/renderers/RadarRenderer.js
+  var RadarRenderer = class {
+    static type = "radar";
+    static traits = {
+      hasAxes: false,
+      referenceLines: false,
+      legendType: "ordinal",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: {}
+    };
+    static scaleHints = null;
+    static dataContract = {
+      axis: { required: true },
+      value: { required: true, numeric: true }
+    };
+    render(chart, layer) {
+      var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+      var width = (chart.width || chart.runtime && chart.runtime.width || 0) - margin.left - margin.right;
+      var height = (chart.height || chart.runtime && chart.runtime.height || 0) - margin.top - margin.bottom;
+      var axisVar = layer.mapping.axis;
+      var valueVar = layer.mapping.value;
+      var groupVar = layer.mapping.group;
+      var labelOffset = layer.options && layer.options.labelOffset || 16;
+      var centerX = width / 2;
+      var centerY = height / 2;
+      var maxRadius = Math.max(0, Math.min(width, height) / 2 - labelOffset - 8);
+      var axisOrder = [];
+      var axisSeen = /* @__PURE__ */ new Set();
+      var maxValue = d3.max(layer.data, function(d) {
+        return +d[valueVar];
+      }) || 0;
+      var radiusScale = d3.scaleLinear().domain([0, maxValue > 0 ? maxValue : 1]).range([0, maxRadius]);
+      var groups = [];
+      var groupMap = groupVar ? d3.group(layer.data, function(d) {
+        return d[groupVar];
+      }) : /* @__PURE__ */ new Map([[layer.label || "Series", layer.data]]);
+      var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+      var axisCount;
+      var root;
+      var axisLayer;
+      var polygonLayer;
+      var lineGenerator;
+      layer.data.forEach(function(d) {
+        var axisName = d[axisVar];
+        if (!axisSeen.has(axisName)) {
+          axisSeen.add(axisName);
+          axisOrder.push(axisName);
+        }
+      });
+      axisCount = axisOrder.length;
+      if (axisCount === 0) {
+        return;
+      }
+      root = chart.dom.chartArea.selectAll(".tag-radar-" + layer.id).data([null]).join("g").attr("class", "tag-radar-" + layer.id);
+      axisLayer = root.selectAll(".radar-axis-layer").data([null]).join("g").attr("class", "radar-axis-layer");
+      polygonLayer = root.selectAll(".radar-polygon-layer").data([null]).join("g").attr("class", "radar-polygon-layer");
+      axisLayer.selectAll(".radar-axis").data(axisOrder).join(function(enter) {
+        var group = enter.append("g").attr("class", "radar-axis");
+        group.append("line").attr("class", "radar-axis-line");
+        group.append("text").attr("class", "radar-axis-label");
+        return group;
+      }).each(function(axisName, index) {
+        var angle = 2 * Math.PI * index / axisCount;
+        var lineX = centerX + maxRadius * Math.sin(angle);
+        var lineY = centerY - maxRadius * Math.cos(angle);
+        var labelX = centerX + (maxRadius + labelOffset) * Math.sin(angle);
+        var labelY = centerY - (maxRadius + labelOffset) * Math.cos(angle);
+        var textAnchor = "middle";
+        if (Math.sin(angle) > 0.25) {
+          textAnchor = "start";
+        } else if (Math.sin(angle) < -0.25) {
+          textAnchor = "end";
+        }
+        d3.select(this).select(".radar-axis-line").attr("x1", centerX).attr("y1", centerY).attr("x2", lineX).attr("y2", lineY);
+        d3.select(this).select(".radar-axis-label").attr("x", labelX).attr("y", labelY).attr("dy", "0.35em").attr("text-anchor", textAnchor).text(axisName);
+      });
+      groupMap.forEach(function(rows, key) {
+        var rowByAxis = /* @__PURE__ */ new Map();
+        var polygonPoints = [];
+        rows.forEach(function(d) {
+          rowByAxis.set(d[axisVar], d);
+        });
+        axisOrder.forEach(function(axisName, index) {
+          var angle = 2 * Math.PI * index / axisCount;
+          var datum = rowByAxis.get(axisName);
+          var rawValue = datum ? +datum[valueVar] : 0;
+          var scaledRadius = radiusScale(Number.isFinite(rawValue) ? rawValue : 0);
+          polygonPoints.push({
+            axis: axisName,
+            angle,
+            value: Number.isFinite(rawValue) ? rawValue : 0,
+            x: centerX + scaledRadius * Math.sin(angle),
+            y: centerY - scaledRadius * Math.cos(angle),
+            datum: datum || null
+          });
+        });
+        groups.push({
+          key,
+          color: colorScale(key),
+          points: polygonPoints,
+          rows
+        });
+      });
+      chart.derived.colorDiscrete = colorScale.domain(groups.map(function(group) {
+        return group.key;
+      }));
+      chart.colorDiscrete = chart.derived.colorDiscrete;
+      lineGenerator = d3.line().x(function(d) {
+        return d.x;
+      }).y(function(d) {
+        return d.y;
+      }).curve(d3.curveLinearClosed);
+      polygonLayer.selectAll(".radar-polygon").data(groups).join("path").attr("class", "radar-polygon").attr("d", function(d) {
+        return lineGenerator(d.points);
+      }).attr("fill", function(d) {
+        return d.color;
+      }).attr("fill-opacity", 0.2).attr("stroke", function(d) {
+        return d.color;
+      }).attr("stroke-width", 2);
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-radar-" + layer.id + " .radar-polygon";
+    }
+    formatTooltip(chart, d) {
+      return {
+        title: { text: String(d.key) },
+        items: d.points.map(function(point) {
+          return {
+            color: d.color,
+            label: point.axis,
+            value: String(point.value)
+          };
+        })
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-radar-" + layer.id).remove();
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/renderers/FunnelRenderer.js
+  var FunnelRenderer = class {
+    static type = "funnel";
+    static traits = {
+      hasAxes: false,
+      referenceLines: false,
+      legendType: "ordinal",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: {}
+    };
+    static scaleHints = null;
+    static dataContract = {
+      stage: { required: true },
+      value: { required: true, numeric: true }
+    };
+    render(chart, layer) {
+      var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+      var width = (chart.width || chart.runtime && chart.runtime.width || 0) - margin.left - margin.right;
+      var height = (chart.height || chart.runtime && chart.runtime.height || 0) - margin.top - margin.bottom;
+      var stageVar = layer.mapping.stage;
+      var valueVar = layer.mapping.value;
+      var stageGap = layer.options && layer.options.stageGap || 6;
+      var maxValue = d3.max(layer.data, function(d) {
+        return +d[valueVar];
+      }) || 0;
+      var widthScale = d3.scaleLinear().domain([0, maxValue > 0 ? maxValue : 1]).range([0, width * 0.95]);
+      var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeTableau10);
+      var stageHeight = layer.data.length > 0 ? height / layer.data.length : 0;
+      var stages;
+      var root;
+      var stageGroups;
+      stages = layer.data.map(function(d, index) {
+        var nextDatum = layer.data[index + 1] || null;
+        var topWidth = widthScale(+d[valueVar] || 0);
+        var bottomWidth = nextDatum ? widthScale(+nextDatum[valueVar] || 0) : topWidth * 0.55;
+        var y0 = index * stageHeight;
+        var y1 = Math.max(y0, y0 + stageHeight - stageGap);
+        var centerX = width / 2;
+        var topLeft = centerX - topWidth / 2;
+        var topRight = centerX + topWidth / 2;
+        var bottomLeft = centerX - bottomWidth / 2;
+        var bottomRight = centerX + bottomWidth / 2;
+        return {
+          stage: d[stageVar],
+          value: +d[valueVar],
+          color: colorScale(d[stageVar]),
+          datum: d,
+          points: [
+            [topLeft, y0],
+            [topRight, y0],
+            [bottomRight, y1],
+            [bottomLeft, y1]
+          ],
+          labelX: centerX,
+          labelY: (y0 + y1) / 2
+        };
+      });
+      chart.derived.colorDiscrete = colorScale.domain(stages.map(function(stage) {
+        return stage.stage;
+      }));
+      chart.colorDiscrete = chart.derived.colorDiscrete;
+      root = chart.dom.chartArea.selectAll(".tag-funnel-" + layer.id).data([null]).join("g").attr("class", "tag-funnel-" + layer.id);
+      stageGroups = root.selectAll(".funnel-stage-group").data(stages).join(function(enter) {
+        var group = enter.append("g").attr("class", "funnel-stage-group");
+        group.append("path").attr("class", "funnel-stage");
+        group.append("text").attr("class", "funnel-label");
+        return group;
+      });
+      stageGroups.select(".funnel-stage").attr("d", function(d) {
+        return "M" + d.points[0][0] + "," + d.points[0][1] + "L" + d.points[1][0] + "," + d.points[1][1] + "L" + d.points[2][0] + "," + d.points[2][1] + "L" + d.points[3][0] + "," + d.points[3][1] + "Z";
+      }).attr("fill", function(d) {
+        return d.color;
+      });
+      stageGroups.select(".funnel-label").attr("x", function(d) {
+        return d.labelX;
+      }).attr("y", function(d) {
+        return d.labelY;
+      }).attr("dy", "0.35em").attr("text-anchor", "middle").text(function(d) {
+        return d.stage;
+      });
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-funnel-" + layer.id + " .funnel-stage";
+    }
+    formatTooltip(chart, d) {
+      return {
+        title: { text: String(d.stage) },
+        items: [{ color: d.color, label: String(d.stage), value: String(d.value) }]
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-funnel-" + layer.id).remove();
+    }
+  };
+
+  // inst/htmlwidgets/myIO/src/renderers/ParallelRenderer.js
+  var ParallelRenderer = class {
+    static type = "parallel";
+    static traits = {
+      hasAxes: false,
+      referenceLines: false,
+      legendType: "ordinal",
+      binning: false,
+      rolloverStyle: "element",
+      scaleCapabilities: {}
+    };
+    static scaleHints = null;
+    static dataContract = {
+      dimensions: { required: true }
+    };
+    render(chart, layer) {
+      var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+      var width = (chart.width || chart.runtime && chart.runtime.width || 0) - margin.left - margin.right;
+      var height = (chart.height || chart.runtime && chart.runtime.height || 0) - margin.top - margin.bottom;
+      var rawDimensions = layer.mapping.dimensions;
+      var dimensions = Array.isArray(rawDimensions) ? rawDimensions.slice() : [rawDimensions];
+      var groupVar = layer.mapping.group;
+      var xScale = d3.scalePoint().domain(dimensions).range([0, width]).padding(0.5);
+      var yScales = {};
+      var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+      var root;
+      var axisGroups;
+      var lineGenerator;
+      dimensions.forEach(function(dimension) {
+        var extent = d3.extent(layer.data, function(row) {
+          var value = +row[dimension];
+          return Number.isFinite(value) ? value : null;
+        });
+        if (!extent || extent[0] === void 0 || extent[1] === void 0) {
+          extent = [0, 1];
+        }
+        if (extent[0] === extent[1]) {
+          extent = [extent[0] - 1, extent[1] + 1];
+        }
+        yScales[dimension] = d3.scaleLinear().domain(extent).range([height, 0]);
+      });
+      chart.derived.colorDiscrete = colorScale.domain(Array.from(new Set(layer.data.map(function(row) {
+        return groupVar ? row[groupVar] : layer.label;
+      }))));
+      chart.colorDiscrete = chart.derived.colorDiscrete;
+      root = chart.dom.chartArea.selectAll(".tag-parallel-" + layer.id).data([null]).join("g").attr("class", "tag-parallel-" + layer.id);
+      axisGroups = root.selectAll(".parallel-axis").data(dimensions).join(function(enter) {
+        var group = enter.append("g").attr("class", "parallel-axis");
+        group.append("text").attr("class", "parallel-axis-label");
+        return group;
+      }).attr("transform", function(dimension) {
+        return "translate(" + xScale(dimension) + ",0)";
+      }).each(function(dimension) {
+        d3.select(this).call(d3.axisLeft(yScales[dimension]).ticks(5));
+      });
+      axisGroups.select(".parallel-axis-label").attr("x", 0).attr("y", -10).attr("text-anchor", "middle").text(function(dimension) {
+        return dimension;
+      });
+      lineGenerator = d3.line().defined(function(point) {
+        return point && point[1] !== null;
+      }).x(function(point) {
+        return point[0];
+      }).y(function(point) {
+        return point[1];
+      });
+      root.selectAll(".parallel-line").data(layer.data).join("path").attr("class", "parallel-line").attr("d", function(row) {
+        var points = dimensions.map(function(dimension) {
+          var value = +row[dimension];
+          if (!Number.isFinite(value)) {
+            return [xScale(dimension), null];
+          }
+          return [xScale(dimension), yScales[dimension](value)];
+        });
+        return lineGenerator(points);
+      }).attr("stroke", function(row) {
+        var colorKey = groupVar ? row[groupVar] : layer.label;
+        return colorScale(colorKey);
+      });
+    }
+    getHoverSelector(chart, layer) {
+      return ".tag-parallel-" + layer.id + " .parallel-line";
+    }
+    formatTooltip(chart, d, layer) {
+      var dimensions = Array.isArray(layer.mapping.dimensions) ? layer.mapping.dimensions : [layer.mapping.dimensions];
+      var title = layer.mapping.group ? String(d[layer.mapping.group]) : String(layer.label || "Series");
+      return {
+        title: { text: title },
+        items: dimensions.map(function(dimension) {
+          return {
+            color: chart.colorDiscrete ? chart.colorDiscrete(layer.mapping.group ? d[layer.mapping.group] : layer.label) : layer.color,
+            label: dimension,
+            value: String(d[dimension])
+          };
+        })
+      };
+    }
+    remove(chart, layer) {
+      chart.dom.chartArea.selectAll(".tag-parallel-" + layer.id).remove();
+    }
+  };
+
   // inst/htmlwidgets/myIO/src/registry.js
   var rendererRegistry = /* @__PURE__ */ new Map();
   function registerRenderer(type, RendererClass) {
@@ -2984,6 +3334,15 @@
     }
     if (!rendererRegistry.has(BumpRenderer.type)) {
       registerRenderer(BumpRenderer.type, new BumpRenderer());
+    }
+    if (!rendererRegistry.has(RadarRenderer.type)) {
+      registerRenderer(RadarRenderer.type, new RadarRenderer());
+    }
+    if (!rendererRegistry.has(FunnelRenderer.type)) {
+      registerRenderer(FunnelRenderer.type, new FunnelRenderer());
+    }
+    if (!rendererRegistry.has(ParallelRenderer.type)) {
+      registerRenderer(ParallelRenderer.type, new ParallelRenderer());
     }
     if (!rendererRegistry.has(TextRenderer.type)) {
       registerRenderer(TextRenderer.type, new TextRenderer());
@@ -4198,7 +4557,10 @@
     donut: "standalone-donut",
     gauge: "standalone-gauge",
     text: "axes-continuous",
-    bracket: "axes-continuous"
+    bracket: "axes-continuous",
+    radar: "standalone-radar",
+    funnel: "standalone-funnel",
+    parallel: "standalone-parallel"
   };
   var CROSS_GROUP_ALLOWED = /* @__PURE__ */ new Set([
     "axes-continuous:axes-categorical",

--- a/inst/htmlwidgets/myIO/src/derive/chart-render.js
+++ b/inst/htmlwidgets/myIO/src/derive/chart-render.js
@@ -7,7 +7,7 @@ export function getPrimaryType(chart) {
 }
 
 export function isAxesChart(type) {
-  return ["treemap", "gauge", "donut", "sankey"].indexOf(type) === -1;
+  return ["treemap", "gauge", "donut", "sankey", "radar", "funnel", "parallel"].indexOf(type) === -1;
 }
 
 export function usesHistogramBins(type) {
@@ -19,7 +19,7 @@ export function usesContinuousLegend(type) {
 }
 
 export function usesOrdinalLegend(type) {
-  return type === "treemap" || type === "donut" || type === "sankey";
+  return type === "treemap" || type === "donut" || type === "sankey" || type === "radar" || type === "funnel" || type === "parallel";
 }
 
 export function needsReferenceLines(type) {

--- a/inst/htmlwidgets/myIO/src/derive/validate.js
+++ b/inst/htmlwidgets/myIO/src/derive/validate.js
@@ -20,7 +20,10 @@ const COMPAT_GROUP = {
   donut: "standalone-donut",
   gauge: "standalone-gauge",
   text: "axes-continuous",
-  bracket: "axes-continuous"
+  bracket: "axes-continuous",
+  radar: "standalone-radar",
+  funnel: "standalone-funnel",
+  parallel: "standalone-parallel"
 };
 
 const CROSS_GROUP_ALLOWED = new Set([

--- a/inst/htmlwidgets/myIO/src/layout/legend-data.js
+++ b/inst/htmlwidgets/myIO/src/layout/legend-data.js
@@ -44,6 +44,18 @@ export function buildOrdinalLegendData(chart, layer) {
     keys = layer.data.map(function(d) {
       return d[layer.mapping.x_var];
     });
+  } else if (layer.type === "funnel" && Array.isArray(layer.data)) {
+    keys = layer.data.map(function(d) {
+      return d[layer.mapping.stage];
+    });
+  } else if (layer.type === "radar" && Array.isArray(layer.data)) {
+    keys = layer.mapping.group
+      ? Array.from(new Set(layer.data.map(function(d) { return d[layer.mapping.group]; })))
+      : [layer.label];
+  } else if (layer.type === "parallel" && Array.isArray(layer.data)) {
+    keys = layer.mapping.group
+      ? Array.from(new Set(layer.data.map(function(d) { return d[layer.mapping.group]; })))
+      : [layer.label];
   }
 
   return {

--- a/inst/htmlwidgets/myIO/src/registry.js
+++ b/inst/htmlwidgets/myIO/src/registry.js
@@ -22,6 +22,9 @@ import { DumbbellRenderer } from "./renderers/DumbbellRenderer.js";
 import { WaffleRenderer } from "./renderers/WaffleRenderer.js";
 import { BeeswarmRenderer } from "./renderers/BeeswarmRenderer.js";
 import { BumpRenderer } from "./renderers/BumpRenderer.js";
+import { RadarRenderer } from "./renderers/RadarRenderer.js";
+import { FunnelRenderer } from "./renderers/FunnelRenderer.js";
+import { ParallelRenderer } from "./renderers/ParallelRenderer.js";
 
 export function registerRenderer(type, RendererClass) {
   if (rendererRegistry.has(type)) {
@@ -114,6 +117,15 @@ export function registerBuiltInRenderers() {
   }
   if (!rendererRegistry.has(BumpRenderer.type)) {
     registerRenderer(BumpRenderer.type, new BumpRenderer());
+  }
+  if (!rendererRegistry.has(RadarRenderer.type)) {
+    registerRenderer(RadarRenderer.type, new RadarRenderer());
+  }
+  if (!rendererRegistry.has(FunnelRenderer.type)) {
+    registerRenderer(FunnelRenderer.type, new FunnelRenderer());
+  }
+  if (!rendererRegistry.has(ParallelRenderer.type)) {
+    registerRenderer(ParallelRenderer.type, new ParallelRenderer());
   }
 
   if (!rendererRegistry.has(TextRenderer.type)) {

--- a/inst/htmlwidgets/myIO/src/renderers/FunnelRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/FunnelRenderer.js
@@ -1,0 +1,113 @@
+export class FunnelRenderer {
+  static type = "funnel";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "ordinal",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: {}
+  };
+  static scaleHints = null;
+  static dataContract = {
+    stage: { required: true },
+    value: { required: true, numeric: true }
+  };
+
+  render(chart, layer) {
+    var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+    var width = ((chart.width || (chart.runtime && chart.runtime.width) || 0) - margin.left - margin.right);
+    var height = ((chart.height || (chart.runtime && chart.runtime.height) || 0) - margin.top - margin.bottom);
+    var stageVar = layer.mapping.stage;
+    var valueVar = layer.mapping.value;
+    var stageGap = (layer.options && layer.options.stageGap) || 6;
+    var maxValue = d3.max(layer.data, function(d) {
+      return +d[valueVar];
+    }) || 0;
+    var widthScale = d3.scaleLinear()
+      .domain([0, maxValue > 0 ? maxValue : 1])
+      .range([0, width * 0.95]);
+    var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeTableau10);
+    var stageHeight = layer.data.length > 0 ? height / layer.data.length : 0;
+    var stages;
+    var root;
+    var stageGroups;
+
+    stages = layer.data.map(function(d, index) {
+      var nextDatum = layer.data[index + 1] || null;
+      var topWidth = widthScale(+d[valueVar] || 0);
+      var bottomWidth = nextDatum ? widthScale(+nextDatum[valueVar] || 0) : topWidth * 0.55;
+      var y0 = index * stageHeight;
+      var y1 = Math.max(y0, y0 + stageHeight - stageGap);
+      var centerX = width / 2;
+      var topLeft = centerX - topWidth / 2;
+      var topRight = centerX + topWidth / 2;
+      var bottomLeft = centerX - bottomWidth / 2;
+      var bottomRight = centerX + bottomWidth / 2;
+      return {
+        stage: d[stageVar],
+        value: +d[valueVar],
+        color: colorScale(d[stageVar]),
+        datum: d,
+        points: [
+          [topLeft, y0],
+          [topRight, y0],
+          [bottomRight, y1],
+          [bottomLeft, y1]
+        ],
+        labelX: centerX,
+        labelY: (y0 + y1) / 2
+      };
+    });
+
+    chart.derived.colorDiscrete = colorScale.domain(stages.map(function(stage) {
+      return stage.stage;
+    }));
+    chart.colorDiscrete = chart.derived.colorDiscrete;
+
+    root = chart.dom.chartArea.selectAll(".tag-funnel-" + layer.id)
+      .data([null])
+      .join("g")
+      .attr("class", "tag-funnel-" + layer.id);
+
+    stageGroups = root.selectAll(".funnel-stage-group")
+      .data(stages)
+      .join(function(enter) {
+        var group = enter.append("g").attr("class", "funnel-stage-group");
+        group.append("path").attr("class", "funnel-stage");
+        group.append("text").attr("class", "funnel-label");
+        return group;
+      });
+
+    stageGroups.select(".funnel-stage")
+      .attr("d", function(d) {
+        return "M" + d.points[0][0] + "," + d.points[0][1] +
+          "L" + d.points[1][0] + "," + d.points[1][1] +
+          "L" + d.points[2][0] + "," + d.points[2][1] +
+          "L" + d.points[3][0] + "," + d.points[3][1] + "Z";
+      })
+      .attr("fill", function(d) { return d.color; });
+
+    stageGroups.select(".funnel-label")
+      .attr("x", function(d) { return d.labelX; })
+      .attr("y", function(d) { return d.labelY; })
+      .attr("dy", "0.35em")
+      .attr("text-anchor", "middle")
+      .text(function(d) { return d.stage; });
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-funnel-" + layer.id + " .funnel-stage";
+  }
+
+  formatTooltip(chart, d) {
+    return {
+      title: { text: String(d.stage) },
+      items: [{ color: d.color, label: String(d.stage), value: String(d.value) }]
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-funnel-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/src/renderers/ParallelRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/ParallelRenderer.js
@@ -1,0 +1,130 @@
+export class ParallelRenderer {
+  static type = "parallel";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "ordinal",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: {}
+  };
+  static scaleHints = null;
+  static dataContract = {
+    dimensions: { required: true }
+  };
+
+  render(chart, layer) {
+    var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+    var width = ((chart.width || (chart.runtime && chart.runtime.width) || 0) - margin.left - margin.right);
+    var height = ((chart.height || (chart.runtime && chart.runtime.height) || 0) - margin.top - margin.bottom);
+    var rawDimensions = layer.mapping.dimensions;
+    var dimensions = Array.isArray(rawDimensions) ? rawDimensions.slice() : [rawDimensions];
+    var groupVar = layer.mapping.group;
+    var xScale = d3.scalePoint()
+      .domain(dimensions)
+      .range([0, width])
+      .padding(0.5);
+    var yScales = {};
+    var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+    var root;
+    var axisGroups;
+    var lineGenerator;
+
+    dimensions.forEach(function(dimension) {
+      var extent = d3.extent(layer.data, function(row) {
+        var value = +row[dimension];
+        return Number.isFinite(value) ? value : null;
+      });
+      if (!extent || extent[0] === undefined || extent[1] === undefined) {
+        extent = [0, 1];
+      }
+      if (extent[0] === extent[1]) {
+        extent = [extent[0] - 1, extent[1] + 1];
+      }
+      yScales[dimension] = d3.scaleLinear()
+        .domain(extent)
+        .range([height, 0]);
+    });
+
+    chart.derived.colorDiscrete = colorScale.domain(Array.from(new Set(layer.data.map(function(row) {
+      return groupVar ? row[groupVar] : layer.label;
+    }))));
+    chart.colorDiscrete = chart.derived.colorDiscrete;
+
+    root = chart.dom.chartArea.selectAll(".tag-parallel-" + layer.id)
+      .data([null])
+      .join("g")
+      .attr("class", "tag-parallel-" + layer.id);
+
+    axisGroups = root.selectAll(".parallel-axis")
+      .data(dimensions)
+      .join(function(enter) {
+        var group = enter.append("g").attr("class", "parallel-axis");
+        group.append("text").attr("class", "parallel-axis-label");
+        return group;
+      })
+      .attr("transform", function(dimension) {
+        return "translate(" + xScale(dimension) + ",0)";
+      })
+      .each(function(dimension) {
+        d3.select(this).call(d3.axisLeft(yScales[dimension]).ticks(5));
+      });
+
+    axisGroups.select(".parallel-axis-label")
+      .attr("x", 0)
+      .attr("y", -10)
+      .attr("text-anchor", "middle")
+      .text(function(dimension) { return dimension; });
+
+    lineGenerator = d3.line()
+      .defined(function(point) {
+        return point && point[1] !== null;
+      })
+      .x(function(point) { return point[0]; })
+      .y(function(point) { return point[1]; });
+
+    root.selectAll(".parallel-line")
+      .data(layer.data)
+      .join("path")
+      .attr("class", "parallel-line")
+      .attr("d", function(row) {
+        var points = dimensions.map(function(dimension) {
+          var value = +row[dimension];
+          if (!Number.isFinite(value)) {
+            return [xScale(dimension), null];
+          }
+          return [xScale(dimension), yScales[dimension](value)];
+        });
+        return lineGenerator(points);
+      })
+      .attr("stroke", function(row) {
+        var colorKey = groupVar ? row[groupVar] : layer.label;
+        return colorScale(colorKey);
+      });
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-parallel-" + layer.id + " .parallel-line";
+  }
+
+  formatTooltip(chart, d, layer) {
+    var dimensions = Array.isArray(layer.mapping.dimensions) ? layer.mapping.dimensions : [layer.mapping.dimensions];
+    var title = layer.mapping.group ? String(d[layer.mapping.group]) : String(layer.label || "Series");
+    return {
+      title: { text: title },
+      items: dimensions.map(function(dimension) {
+        return {
+          color: chart.colorDiscrete
+            ? chart.colorDiscrete(layer.mapping.group ? d[layer.mapping.group] : layer.label)
+            : layer.color,
+          label: dimension,
+          value: String(d[dimension])
+        };
+      })
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-parallel-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/src/renderers/RadarRenderer.js
+++ b/inst/htmlwidgets/myIO/src/renderers/RadarRenderer.js
@@ -1,0 +1,179 @@
+export class RadarRenderer {
+  static type = "radar";
+  static traits = {
+    hasAxes: false,
+    referenceLines: false,
+    legendType: "ordinal",
+    binning: false,
+    rolloverStyle: "element",
+    scaleCapabilities: {}
+  };
+  static scaleHints = null;
+  static dataContract = {
+    axis: { required: true },
+    value: { required: true, numeric: true }
+  };
+
+  render(chart, layer) {
+    var margin = chart.margin || (chart.config && chart.config.layout ? chart.config.layout.margin : { top: 0, right: 0, bottom: 0, left: 0 });
+    var width = ((chart.width || (chart.runtime && chart.runtime.width) || 0) - margin.left - margin.right);
+    var height = ((chart.height || (chart.runtime && chart.runtime.height) || 0) - margin.top - margin.bottom);
+    var axisVar = layer.mapping.axis;
+    var valueVar = layer.mapping.value;
+    var groupVar = layer.mapping.group;
+    var labelOffset = (layer.options && layer.options.labelOffset) || 16;
+    var centerX = width / 2;
+    var centerY = height / 2;
+    var maxRadius = Math.max(0, Math.min(width, height) / 2 - labelOffset - 8);
+    var axisOrder = [];
+    var axisSeen = new Set();
+    var maxValue = d3.max(layer.data, function(d) {
+      return +d[valueVar];
+    }) || 0;
+    var radiusScale = d3.scaleLinear()
+      .domain([0, maxValue > 0 ? maxValue : 1])
+      .range([0, maxRadius]);
+    var groups = [];
+    var groupMap = groupVar
+      ? d3.group(layer.data, function(d) { return d[groupVar]; })
+      : new Map([[layer.label || "Series", layer.data]]);
+    var colorScale = chart.derived.colorDiscrete || d3.scaleOrdinal(d3.schemeCategory10);
+    var axisCount;
+    var root;
+    var axisLayer;
+    var polygonLayer;
+    var lineGenerator;
+
+    layer.data.forEach(function(d) {
+      var axisName = d[axisVar];
+      if (!axisSeen.has(axisName)) {
+        axisSeen.add(axisName);
+        axisOrder.push(axisName);
+      }
+    });
+
+    axisCount = axisOrder.length;
+    if (axisCount === 0) {
+      return;
+    }
+
+    root = chart.dom.chartArea.selectAll(".tag-radar-" + layer.id)
+      .data([null])
+      .join("g")
+      .attr("class", "tag-radar-" + layer.id);
+
+    axisLayer = root.selectAll(".radar-axis-layer")
+      .data([null])
+      .join("g")
+      .attr("class", "radar-axis-layer");
+
+    polygonLayer = root.selectAll(".radar-polygon-layer")
+      .data([null])
+      .join("g")
+      .attr("class", "radar-polygon-layer");
+
+    axisLayer.selectAll(".radar-axis")
+      .data(axisOrder)
+      .join(function(enter) {
+        var group = enter.append("g").attr("class", "radar-axis");
+        group.append("line").attr("class", "radar-axis-line");
+        group.append("text").attr("class", "radar-axis-label");
+        return group;
+      })
+      .each(function(axisName, index) {
+        var angle = 2 * Math.PI * index / axisCount;
+        var lineX = centerX + maxRadius * Math.sin(angle);
+        var lineY = centerY - maxRadius * Math.cos(angle);
+        var labelX = centerX + (maxRadius + labelOffset) * Math.sin(angle);
+        var labelY = centerY - (maxRadius + labelOffset) * Math.cos(angle);
+        var textAnchor = "middle";
+        if (Math.sin(angle) > 0.25) {
+          textAnchor = "start";
+        } else if (Math.sin(angle) < -0.25) {
+          textAnchor = "end";
+        }
+
+        d3.select(this).select(".radar-axis-line")
+          .attr("x1", centerX)
+          .attr("y1", centerY)
+          .attr("x2", lineX)
+          .attr("y2", lineY);
+
+        d3.select(this).select(".radar-axis-label")
+          .attr("x", labelX)
+          .attr("y", labelY)
+          .attr("dy", "0.35em")
+          .attr("text-anchor", textAnchor)
+          .text(axisName);
+      });
+
+    groupMap.forEach(function(rows, key) {
+      var rowByAxis = new Map();
+      var polygonPoints = [];
+      rows.forEach(function(d) {
+        rowByAxis.set(d[axisVar], d);
+      });
+      axisOrder.forEach(function(axisName, index) {
+        var angle = 2 * Math.PI * index / axisCount;
+        var datum = rowByAxis.get(axisName);
+        var rawValue = datum ? +datum[valueVar] : 0;
+        var scaledRadius = radiusScale(Number.isFinite(rawValue) ? rawValue : 0);
+        polygonPoints.push({
+          axis: axisName,
+          angle: angle,
+          value: Number.isFinite(rawValue) ? rawValue : 0,
+          x: centerX + scaledRadius * Math.sin(angle),
+          y: centerY - scaledRadius * Math.cos(angle),
+          datum: datum || null
+        });
+      });
+      groups.push({
+        key: key,
+        color: colorScale(key),
+        points: polygonPoints,
+        rows: rows
+      });
+    });
+
+    chart.derived.colorDiscrete = colorScale.domain(groups.map(function(group) {
+      return group.key;
+    }));
+    chart.colorDiscrete = chart.derived.colorDiscrete;
+
+    lineGenerator = d3.line()
+      .x(function(d) { return d.x; })
+      .y(function(d) { return d.y; })
+      .curve(d3.curveLinearClosed);
+
+    polygonLayer.selectAll(".radar-polygon")
+      .data(groups)
+      .join("path")
+      .attr("class", "radar-polygon")
+      .attr("d", function(d) { return lineGenerator(d.points); })
+      .attr("fill", function(d) { return d.color; })
+      .attr("fill-opacity", 0.2)
+      .attr("stroke", function(d) { return d.color; })
+      .attr("stroke-width", 2);
+  }
+
+  getHoverSelector(chart, layer) {
+    return ".tag-radar-" + layer.id + " .radar-polygon";
+  }
+
+  formatTooltip(chart, d) {
+    return {
+      title: { text: String(d.key) },
+      items: d.points.map(function(point) {
+        return {
+          color: d.color,
+          label: point.axis,
+          value: String(point.value)
+        };
+      })
+    };
+  }
+
+  remove(chart, layer) {
+    chart.dom.chartArea.selectAll(".tag-radar-" + layer.id).remove();
+  }
+}

--- a/inst/htmlwidgets/myIO/style.css
+++ b/inst/htmlwidgets/myIO/style.css
@@ -834,3 +834,19 @@
   font-weight: 600;
   color: var(--chart-text-color);
 }
+
+/* Radar */
+.radar-polygon { transition: opacity 0.15s ease; }
+.radar-polygon:hover { opacity: 0.9; }
+.radar-axis-line { stroke: var(--chart-grid-color); stroke-opacity: 0.3; }
+.radar-axis-label { font-size: 11px; fill: var(--chart-text-color); }
+
+/* Funnel */
+.funnel-stage { cursor: pointer; transition: opacity 0.15s ease; }
+.funnel-stage:hover { opacity: 0.85; }
+.funnel-label { font-size: 12px; fill: var(--chart-text-color); font-weight: 600; }
+
+/* Parallel coordinates */
+.parallel-line { fill: none; stroke-opacity: 0.4; transition: stroke-opacity 0.15s ease; }
+.parallel-line:hover { stroke-opacity: 1; stroke-width: 2; }
+.parallel-axis-label { font-size: 11px; fill: var(--chart-text-color); }

--- a/tests/js/chart-render.test.js
+++ b/tests/js/chart-render.test.js
@@ -25,6 +25,9 @@ describe("chart-render utility functions", function() {
     expect(isAxesChart("gauge")).toBe(false);
     expect(isAxesChart("donut")).toBe(false);
     expect(isAxesChart("sankey")).toBe(false);
+    expect(isAxesChart("radar")).toBe(false);
+    expect(isAxesChart("funnel")).toBe(false);
+    expect(isAxesChart("parallel")).toBe(false);
   });
 
   test("isAxesChart returns true for axes types", function() {
@@ -53,6 +56,9 @@ describe("chart-render utility functions", function() {
     expect(usesOrdinalLegend("treemap")).toBe(true);
     expect(usesOrdinalLegend("donut")).toBe(true);
     expect(usesOrdinalLegend("sankey")).toBe(true);
+    expect(usesOrdinalLegend("radar")).toBe(true);
+    expect(usesOrdinalLegend("funnel")).toBe(true);
+    expect(usesOrdinalLegend("parallel")).toBe(true);
     expect(usesOrdinalLegend("bar")).toBe(false);
   });
 
@@ -112,6 +118,14 @@ describe("deriveChartRender", function() {
 
   test("derives correct state for treemap layers", function() {
     var chart = { derived: { currentLayers: [{ type: "treemap" }] } };
+    var state = deriveChartRender(chart);
+    expect(state.ordinalLegend).toBe(true);
+    expect(state.axesChart).toBe(false);
+    expect(state.referenceLines).toBe(false);
+  });
+
+  test("derives correct state for radar layers", function() {
+    var chart = { derived: { currentLayers: [{ type: "radar" }] } };
     var state = deriveChartRender(chart);
     expect(state.ordinalLegend).toBe(true);
     expect(state.axesChart).toBe(false);

--- a/tests/js/renderers.test.js
+++ b/tests/js/renderers.test.js
@@ -45,8 +45,8 @@ describe("Renderer static properties", function() {
     registerBuiltInRenderers();
   });
 
-  test("all 17 renderer types are registered", function() {
-    var types = ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "treemap", "donut", "gauge", "heatmap", "candlestick", "waterfall", "sankey", "rangeBar", "text", "bracket"];
+  test("all built-in renderer types are registered", function() {
+    var types = ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "treemap", "donut", "gauge", "heatmap", "candlestick", "waterfall", "sankey", "rangeBar", "text", "bracket", "lollipop", "dumbbell", "waffle", "beeswarm", "bump", "radar", "funnel", "parallel"];
     types.forEach(function(type) {
       var renderer = getRenderer(type);
       expect(renderer).toBeDefined();
@@ -55,7 +55,7 @@ describe("Renderer static properties", function() {
   });
 
   test("each renderer has traits and dataContract", function() {
-    var types = ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "treemap", "donut", "gauge", "heatmap", "candlestick", "waterfall", "sankey", "rangeBar", "text", "bracket"];
+    var types = ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "treemap", "donut", "gauge", "heatmap", "candlestick", "waterfall", "sankey", "rangeBar", "text", "bracket", "lollipop", "dumbbell", "waffle", "beeswarm", "bump", "radar", "funnel", "parallel"];
     types.forEach(function(type) {
       var renderer = getRenderer(type);
       expect(renderer.constructor.traits).toBeDefined();
@@ -65,13 +65,13 @@ describe("Renderer static properties", function() {
   });
 
   test("standalone types have hasAxes=false", function() {
-    ["treemap", "donut", "gauge", "sankey"].forEach(function(type) {
+    ["treemap", "donut", "gauge", "sankey", "waffle", "radar", "funnel", "parallel"].forEach(function(type) {
       expect(getRenderer(type).constructor.traits.hasAxes).toBe(false);
     });
   });
 
   test("axes types have hasAxes=true", function() {
-    ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "heatmap", "candlestick", "waterfall", "rangeBar", "bracket"].forEach(function(type) {
+    ["line", "point", "area", "bar", "groupedBar", "histogram", "hexbin", "heatmap", "candlestick", "waterfall", "rangeBar", "bracket", "lollipop", "dumbbell", "beeswarm", "bump"].forEach(function(type) {
       expect(getRenderer(type).constructor.traits.hasAxes).toBe(true);
     });
   });
@@ -316,6 +316,93 @@ describe("Renderer formatTooltip methods", function() {
 
     expect(document.querySelectorAll("rect." + "tag-sankey-node-chart-flow").length).toBeGreaterThan(0);
     expect(document.querySelectorAll("path." + "tag-sankey-chart-flow").length).toBeGreaterThan(0);
+  });
+
+  test("RadarRenderer.render creates axes and group polygons", function() {
+    var renderer = getRenderer("radar");
+    document.body.innerHTML = "<div id='chart'><svg><g class='myIO-chart-area'></g></svg></div>";
+    var el = document.getElementById("chart");
+    var chart = {
+      dom: { chartArea: d3.select(el).select(".myIO-chart-area") },
+      derived: {},
+      margin: { top: 30, bottom: 30, left: 30, right: 30 },
+      width: 320,
+      height: 320
+    };
+    var layer = {
+      id: "radar_1",
+      label: "skills",
+      mapping: { axis: "axis", value: "value", group: "series" },
+      data: [
+        { axis: "A", value: 3, series: "Alpha" },
+        { axis: "B", value: 5, series: "Alpha" },
+        { axis: "C", value: 4, series: "Alpha" },
+        { axis: "A", value: 4, series: "Beta" },
+        { axis: "B", value: 2, series: "Beta" },
+        { axis: "C", value: 5, series: "Beta" }
+      ]
+    };
+
+    renderer.render(chart, layer);
+
+    expect(document.querySelectorAll(".tag-radar-radar_1 .radar-axis").length).toBe(3);
+    expect(document.querySelectorAll(".tag-radar-radar_1 .radar-polygon").length).toBe(2);
+  });
+
+  test("FunnelRenderer.render creates trapezoid stages", function() {
+    var renderer = getRenderer("funnel");
+    document.body.innerHTML = "<div id='chart'><svg><g class='myIO-chart-area'></g></svg></div>";
+    var el = document.getElementById("chart");
+    var chart = {
+      dom: { chartArea: d3.select(el).select(".myIO-chart-area") },
+      derived: {},
+      margin: { top: 20, bottom: 20, left: 20, right: 20 },
+      width: 360,
+      height: 260
+    };
+    var layer = {
+      id: "funnel_1",
+      label: "pipeline",
+      mapping: { stage: "stage", value: "value" },
+      data: [
+        { stage: "Visit", value: 100 },
+        { stage: "Lead", value: 60 },
+        { stage: "Won", value: 20 }
+      ]
+    };
+
+    renderer.render(chart, layer);
+
+    expect(document.querySelectorAll(".tag-funnel-funnel_1 .funnel-stage").length).toBe(3);
+    expect(document.querySelectorAll(".tag-funnel-funnel_1 .funnel-label").length).toBe(3);
+  });
+
+  test("ParallelRenderer.render creates axes and polylines", function() {
+    var renderer = getRenderer("parallel");
+    document.body.innerHTML = "<div id='chart'><svg><g class='myIO-chart-area'></g></svg></div>";
+    var el = document.getElementById("chart");
+    var chart = {
+      dom: { chartArea: d3.select(el).select(".myIO-chart-area") },
+      derived: {},
+      margin: { top: 20, bottom: 20, left: 20, right: 20 },
+      width: 420,
+      height: 260
+    };
+    var layer = {
+      id: "parallel_1",
+      label: "rows",
+      color: "#4E79A7",
+      mapping: { dimensions: ["speed", "power", "stamina"], group: "team" },
+      data: [
+        { speed: 4, power: 8, stamina: 6, team: "A" },
+        { speed: 7, power: 5, stamina: 9, team: "B" }
+      ]
+    };
+
+    renderer.render(chart, layer);
+
+    expect(document.querySelectorAll(".tag-parallel-parallel_1 .parallel-axis").length).toBe(3);
+    expect(document.querySelectorAll(".tag-parallel-parallel_1 .parallel-line").length).toBe(2);
   });
 
   test("HistogramRenderer.formatTooltip shows bin range", function() {

--- a/tests/testthat/test_funnel.R
+++ b/tests/testthat/test_funnel.R
@@ -1,0 +1,24 @@
+test_that("funnel layer accepts valid inputs", {
+  df <- data.frame(stage = c("Visitors", "Leads", "Qualified", "Closed"),
+                   value = c(1000, 500, 200, 50))
+  p <- myIO(df) |>
+    addIoLayer("funnel", label = "sales", mapping = list(stage = "stage", value = "value"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "funnel")
+})
+
+test_that("funnel rejects missing stage", {
+  df <- data.frame(value = c(1000, 500))
+  expect_error(
+    myIO(df) |> addIoLayer("funnel", label = "f", mapping = list(value = "value")),
+    "stage"
+  )
+})
+
+test_that("funnel rejects missing value", {
+  df <- data.frame(stage = c("A", "B"))
+  expect_error(
+    myIO(df) |> addIoLayer("funnel", label = "f", mapping = list(stage = "stage")),
+    "value"
+  )
+})

--- a/tests/testthat/test_parallel.R
+++ b/tests/testthat/test_parallel.R
@@ -1,0 +1,15 @@
+test_that("parallel coords layer accepts valid inputs", {
+  p <- myIO(iris) |>
+    addIoLayer("parallel", label = "par",
+               mapping = list(dimensions = c("Sepal.Length", "Sepal.Width",
+                                             "Petal.Length", "Petal.Width")))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "parallel")
+})
+
+test_that("parallel rejects missing dimensions", {
+  expect_error(
+    myIO(iris) |> addIoLayer("parallel", label = "par", mapping = list()),
+    "dimensions"
+  )
+})

--- a/tests/testthat/test_radar.R
+++ b/tests/testthat/test_radar.R
@@ -1,0 +1,24 @@
+test_that("radar layer accepts valid inputs", {
+  df <- data.frame(axis = c("Speed", "Power", "Range", "Armor", "Magic"),
+                   value = c(80, 60, 90, 40, 70))
+  p <- myIO(df) |>
+    addIoLayer("radar", label = "hero", mapping = list(axis = "axis", value = "value"))
+  expect_s3_class(p, "myIO")
+  expect_equal(p$x$config$layers[[1]]$type, "radar")
+})
+
+test_that("radar rejects missing axis", {
+  df <- data.frame(value = c(80, 60))
+  expect_error(
+    myIO(df) |> addIoLayer("radar", label = "r", mapping = list(value = "value")),
+    "axis"
+  )
+})
+
+test_that("radar rejects missing value", {
+  df <- data.frame(axis = c("A", "B"))
+  expect_error(
+    myIO(df) |> addIoLayer("radar", label = "r", mapping = list(axis = "axis")),
+    "value"
+  )
+})


### PR DESCRIPTION
## Summary

Phase 4 Session 4 — chart type expansion to 30+:

- **Radar**: Spider chart with radial axes, polygon fill, and group support
- **Funnel**: Narrowing centered trapezoids for conversion pipeline data
- **Parallel coordinates**: Vertical axes per dimension with connecting polylines

## Test plan

- [x] R tests: 806/806 pass (4 radar + 4 funnel + 3 parallel = 11 new)
- [x] JS tests: 198/198 pass (4 new render tests)
- [x] Build: 265.8kb bundle
- [ ] Manual: radar chart with 5-axis hero stats
- [ ] Manual: funnel with 4-stage conversion data

🤖 Generated with [Claude Code](https://claude.com/claude-code)