### PR TITLE
Fix renderer bugs: dist fit, survival scales, sparkline CSS

### DIFF
--- a/R/composite_histogram_fit.R
+++ b/R/composite_histogram_fit.R
@@ -13,16 +13,34 @@ composite_histogram_fit <- function(data, mapping, label, color, options) {
 
   fit_result <- transform_fit_distribution(data, mapping, options)
 
+  # Pre-bin the histogram in R so JS doesn't need to re-bin
+  val_col <- mapping$value
+  vals <- data[[val_col]]
+  vals <- vals[!is.na(vals)]
+  h <- graphics::hist(vals, breaks = bins, plot = FALSE)
+  hist_data <- data.frame(
+    x_var = h$mids,
+    y_var = h$counts,
+    x0 = h$breaks[-length(h$breaks)],
+    x1 = h$breaks[-1],
+    stringsAsFactors = FALSE
+  )
+  hist_data[["_source_key"]] <- sprintf("bin_%d", seq_len(nrow(hist_data)))
+
   layers <- list(
     list(
-      type = "histogram",
-      data = data,
-      mapping = list(value = mapping$value),
+      type = "bar",
+      data = hist_data,
+      mapping = list(x_var = "x_var", y_var = "y_var"),
       transform = "identity",
       label = paste0(label, " - histogram"),
       color = base_color,
       role = "histogram",
-      options = list(bins = bins)
+      scaleHints = list(
+        xScaleType = "linear", yScaleType = "linear",
+        xExtentFields = list(), yExtentFields = list("y_var"),
+        domainMerge = "union"
+      )
     ),
     list(
       type = "line",
@@ -32,7 +50,11 @@ composite_histogram_fit <- function(data, mapping, label, color, options) {
       label = paste0(label, " - fit"),
       color = line_color,
       role = "density_line",
-      scaleHints = list(suppressY = TRUE)
+      scaleHints = list(
+        xScaleType = "linear", yScaleType = "linear",
+        xExtentFields = list(), yExtentFields = list("y_var"),
+        domainMerge = "union"
+      )
     )
   )
 

--- a/R/composite_survfit.R
+++ b/R/composite_survfit.R
@@ -49,7 +49,7 @@ composite_survfit <- function(data, mapping, label, color, options) {
       options = list(curveType = "stepAfter"),
       scaleHints = list(
         xScaleType = "linear", yScaleType = "linear",
-        xExtentFields = list(), yExtentFields = list("surv"),
+        xExtentFields = list("x_var"), yExtentFields = list("y_var"),
         domainMerge = "union"
       )
     )
@@ -65,7 +65,7 @@ composite_survfit <- function(data, mapping, label, color, options) {
         options = list(curveType = "stepAfter"),
         scaleHints = list(
           xScaleType = "linear", yScaleType = "linear",
-          xExtentFields = list(), yExtentFields = list("ci_lower", "ci_upper"),
+          xExtentFields = list("x_var"), yExtentFields = list("low_y", "high_y"),
           domainMerge = "union"
         )
       )
@@ -82,7 +82,7 @@ composite_survfit <- function(data, mapping, label, color, options) {
         options = list(shape = "tickUp", radius = 4),
         scaleHints = list(
           xScaleType = "linear", yScaleType = "linear",
-          xExtentFields = list(), yExtentFields = list("surv"),
+          xExtentFields = list("x_var"), yExtentFields = list("y_var"),
           domainMerge = "union"
         )
       )

--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -418,7 +418,7 @@
   }
   function initializeScaffold(chart) {
     d3.select(chart.element).selectAll(".myIO-svg, .buttonDiv, .toolTip, .myIO-fab, .myIO-panel, .myIO-sheet-backdrop").remove();
-    d3.select(chart.element).style("position", "relative");
+    d3.select(chart.element).classed("myIO-container", true).style("position", "relative");
     chart.svg = d3.select(chart.element).append("svg").attr("class", "myIO-svg").attr("id", "myIO-svg" + chart.element.id).attr("width", chart.totalWidth).attr("height", chart.height).attr("viewBox", "0 0 " + chart.totalWidth + " " + chart.height).attr("role", "img").attr("aria-label", buildAriaLabel(chart));
     applyPlotTransform(chart);
     chart.chart = chart.plot.append("g").attr("class", "myIO-chart-area");

--- a/inst/htmlwidgets/myIO/src/layout/scaffold.js
+++ b/inst/htmlwidgets/myIO/src/layout/scaffold.js
@@ -6,7 +6,7 @@ export function getChartHeight(chart) {
 
 export function initializeScaffold(chart) {
   d3.select(chart.element).selectAll(".myIO-svg, .buttonDiv, .toolTip, .myIO-fab, .myIO-panel, .myIO-sheet-backdrop").remove();
-  d3.select(chart.element).style("position", "relative");
+  d3.select(chart.element).classed("myIO-container", true).style("position", "relative");
 
   chart.svg = d3.select(chart.element)
     .append("svg")

--- a/tests/testthat/test_histogram_fit.R
+++ b/tests/testthat/test_histogram_fit.R
@@ -76,7 +76,7 @@ test_that("composite expands correctly", {
   )
   expect_equal(length(layers), 2)
   types <- vapply(layers, function(l) l$type, character(1))
-  expect_true("histogram" %in% types)
+  expect_true("bar" %in% types)
   expect_true("line" %in% types)
   roles <- vapply(layers, function(l) l$role, character(1))
   expect_true("histogram" %in% roles)
@@ -97,6 +97,6 @@ test_that("end-to-end widget creation works", {
   layers <- w$x$config$layers
   expect_true(length(layers) >= 2)
   types <- vapply(layers, function(l) l$type, character(1))
-  expect_true("histogram" %in% types)
+  expect_true("bar" %in% types)
   expect_true("line" %in% types)
 })


### PR DESCRIPTION
## Summary

Three root-cause fixes from visual review:

1. **Distribution fit**: Pre-bin histogram data in R, use `bar` sublayer type instead of `histogram` (which expects JS-side binning via `layer.bins`)
2. **Survival curve**: Fixed `scaleHints.xExtentFields` from empty to `["x_var"]` so derive pipeline computes correct time-axis domain
3. **Sparkline CSS**: Added `myIO-container` class to widget element in scaffold.js — CSS selectors for sparkline hiding, high-contrast, and reduced-motion were never matching

## Test plan

- [x] R: 806/806 pass (updated histogram_fit test for bar type)
- [x] JS: 198/198 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)