### PR TITLE
Fix distribution fit x-axis scale

### DIFF
--- a/R/composite_histogram_fit.R
+++ b/R/composite_histogram_fit.R
@@ -38,7 +38,7 @@ composite_histogram_fit <- function(data, mapping, label, color, options) {
       role = "histogram",
       scaleHints = list(
         xScaleType = "linear", yScaleType = "linear",
-        xExtentFields = list(), yExtentFields = list("y_var"),
+        xExtentFields = list("x_var"), yExtentFields = list("y_var"),
         domainMerge = "union"
       )
     ),
@@ -52,7 +52,7 @@ composite_histogram_fit <- function(data, mapping, label, color, options) {
       role = "density_line",
       scaleHints = list(
         xScaleType = "linear", yScaleType = "linear",
-        xExtentFields = list(), yExtentFields = list("y_var"),
+        xExtentFields = list("x_var"), yExtentFields = list("y_var"),
         domainMerge = "union"
       )
     )


### PR DESCRIPTION
## Summary

Same xExtentFields fix as survival curve (#41) — composite sublayers need explicit extent field declarations for the derive pipeline to compute correct domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)