### PR TITLE
Fix Shiny dropdown reactivity: destroy and recreate on re-render

### DIFF
--- a/inst/htmlwidgets/myIO.js
+++ b/inst/htmlwidgets/myIO.js
@@ -6,8 +6,12 @@ HTMLWidgets.widget({
       renderValue: function(x) {
         if (x.config && x.config.layers) {
           if (this.myIOchart) {
-            this.myIOchart.updateChart(x.config);
-          } else {
+            // Destroy and recreate to handle layer count/type changes cleanly
+            this.myIOchart.destroy();
+            d3.select(el).selectAll("*").remove();
+            this.myIOchart = null;
+          }
+          if (!this.myIOchart) {
             this.myIOchart = new myIOchart({
               element: document.getElementById(el.id),
               config: x.config,


### PR DESCRIPTION
## Summary

The htmlwidgets binding's `updateChart()` path couldn't handle config changes that alter layer count/type (regression method switch, theme preset change). Fix: always destroy and recreate the chart on `renderValue`. Eliminates stale state bugs across all Shiny reactive inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)