### PR TITLE
Fix theme presets not visually applying

### DIFF
--- a/inst/htmlwidgets/myIO/myIOapi.js
+++ b/inst/htmlwidgets/myIO/myIOapi.js
@@ -420,6 +420,7 @@
     d3.select(chart.element).selectAll(".myIO-svg, .buttonDiv, .toolTip, .myIO-fab, .myIO-panel, .myIO-sheet-backdrop").remove();
     d3.select(chart.element).classed("myIO-container", true).style("position", "relative");
     chart.svg = d3.select(chart.element).append("svg").attr("class", "myIO-svg").attr("id", "myIO-svg" + chart.element.id).attr("width", chart.totalWidth).attr("height", chart.height).attr("viewBox", "0 0 " + chart.totalWidth + " " + chart.height).attr("role", "img").attr("aria-label", buildAriaLabel(chart));
+    chart.svg.append("rect").attr("class", "myIO-bg").attr("width", chart.totalWidth).attr("height", chart.height).attr("fill", "var(--chart-bg, #ffffff)");
     applyPlotTransform(chart);
     chart.chart = chart.plot.append("g").attr("class", "myIO-chart-area");
   }

--- a/inst/htmlwidgets/myIO/src/layout/scaffold.js
+++ b/inst/htmlwidgets/myIO/src/layout/scaffold.js
@@ -18,6 +18,13 @@ export function initializeScaffold(chart) {
     .attr("role", "img")
     .attr("aria-label", buildAriaLabel(chart));
 
+  // Background rect that respects theme CSS variable
+  chart.svg.append("rect")
+    .attr("class", "myIO-bg")
+    .attr("width", chart.totalWidth)
+    .attr("height", chart.height)
+    .attr("fill", "var(--chart-bg, #ffffff)");
+
   applyPlotTransform(chart);
 
   chart.chart = chart.plot

--- a/inst/htmlwidgets/myIO/style.css
+++ b/inst/htmlwidgets/myIO/style.css
@@ -64,6 +64,15 @@
   background: var(--chart-bg);
 }
 
+.myIO-container .tick text {
+  fill: var(--chart-text-color);
+}
+
+.myIO-container .tick line,
+.myIO-container .domain {
+  stroke: var(--chart-grid-color);
+}
+
 .inner-text,
 .legendElement,
 .x-label,


### PR DESCRIPTION
## Summary

Theme presets (ocean, midnight, forest, etc.) were setting CSS variables correctly but the chart wasn't consuming them:
1. SVG background: added `<rect>` with `fill="var(--chart-bg)"` since SVG ignores CSS `background`
2. Axis text: added `.tick text { fill: var(--chart-text-color) }` and grid stroke rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)