### PR TITLE
Merge develop: LLM tool-calling, uncertainty viz, a11y, #52 fix

### DIFF
--- a/inst/myio-schema.json
+++ b/inst/myio-schema.json
@@ -98,7 +98,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "mean",
@@ -136,7 +138,9 @@
         "y_var",
         "radius"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-hex",
       "data_contract": {
         "x_var": {
@@ -170,7 +174,9 @@
         "level_2"
       ],
       "numeric_fields": [],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-treemap",
       "data_contract": {
         "level_1": {
@@ -189,9 +195,15 @@
     "gauge": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-gauge",
       "data_contract": {
         "value": {
@@ -208,8 +220,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-donut",
       "data_contract": {
         "x_var": {
@@ -263,8 +279,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": {
         "x_var": {
@@ -290,9 +310,15 @@
     "histogram": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": {
         "value": {
@@ -317,8 +343,12 @@
         "y_var",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-matrix",
       "data_contract": {
         "x_var": {
@@ -357,7 +387,9 @@
         "low",
         "close"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -400,7 +432,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "cumulative"
@@ -433,8 +467,12 @@
         "target",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-flow",
       "data_contract": {
         "source": {
@@ -457,8 +495,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": null,
       "scale_hints": null
@@ -470,8 +512,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": null,
       "scale_hints": null
@@ -484,8 +530,12 @@
         "y_var",
         "group"
       ],
-      "numeric_fields": "x_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "x_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": null,
       "scale_hints": null
@@ -537,8 +587,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {},
       "scale_hints": {
@@ -556,7 +610,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -571,7 +627,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "pairwise_test"
@@ -608,7 +666,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -619,8 +679,12 @@
     "qq": {
       "kind": "composite",
       "renderer_type": false,
-      "required_mappings": "y_var",
-      "numeric_fields": "y_var",
+      "required_mappings": [
+        "y_var"
+      ],
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -635,7 +699,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "mean",
@@ -674,7 +740,9 @@
         "low_y",
         "high_y"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": {
         "x_var": {
@@ -708,8 +776,12 @@
         "category",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-waffle",
       "data_contract": {
         "category": {
@@ -729,8 +801,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -761,8 +837,12 @@
         "y_var",
         "group"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -793,8 +873,12 @@
         "axis",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-radar",
       "data_contract": {
         "axis": {
@@ -814,8 +898,12 @@
         "stage",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-funnel",
       "data_contract": {
         "stage": {
@@ -831,9 +919,13 @@
     "parallel": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "dimensions",
+      "required_mappings": [
+        "dimensions"
+      ],
       "numeric_fields": [],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-parallel",
       "data_contract": {
         "dimensions": {
@@ -853,7 +945,9 @@
         "time",
         "status"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": null,
       "scale_hints": null
@@ -861,9 +955,15 @@
     "histogram_fit": {
       "kind": "composite",
       "renderer_type": false,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": null,
       "scale_hints": null
@@ -875,8 +975,12 @@
         "date",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-calendar",
       "data_contract": {
         "date": {
@@ -896,7 +1000,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "quantile_dots"
@@ -934,8 +1040,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": null,
       "scale_hints": null
@@ -1138,7 +1248,9 @@
       "transform",
       "options"
     ],
-    "clear_duckdb_wasm_cache": "version",
+    "clear_duckdb_wasm_cache": [
+      "version"
+    ],
     "defineCategoricalAxis": [
       "myIO",
       "xAxis",
@@ -1177,9 +1289,15 @@
       "webgl_threshold",
       "unify_data_path"
     ],
-    "myio_chart_schema": "type",
-    "myio_function_signature": "fn",
-    "myIO_last_error": "outputId",
+    "myio_chart_schema": [
+      "type"
+    ],
+    "myio_function_signature": [
+      "fn"
+    ],
+    "myIO_last_error": [
+      "outputId"
+    ],
     "myio_list_chart_types": [],
     "myio_list_functions": [],
     "myio_validate_call": [

--- a/mcp/myio-schema.json
+++ b/mcp/myio-schema.json
@@ -98,7 +98,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "mean",
@@ -136,7 +138,9 @@
         "y_var",
         "radius"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-hex",
       "data_contract": {
         "x_var": {
@@ -170,7 +174,9 @@
         "level_2"
       ],
       "numeric_fields": [],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-treemap",
       "data_contract": {
         "level_1": {
@@ -189,9 +195,15 @@
     "gauge": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-gauge",
       "data_contract": {
         "value": {
@@ -208,8 +220,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-donut",
       "data_contract": {
         "x_var": {
@@ -263,8 +279,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": {
         "x_var": {
@@ -290,9 +310,15 @@
     "histogram": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": {
         "value": {
@@ -317,8 +343,12 @@
         "y_var",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-matrix",
       "data_contract": {
         "x_var": {
@@ -357,7 +387,9 @@
         "low",
         "close"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -400,7 +432,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "cumulative"
@@ -433,8 +467,12 @@
         "target",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-flow",
       "data_contract": {
         "source": {
@@ -457,8 +495,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": null,
       "scale_hints": null
@@ -470,8 +512,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": null,
       "scale_hints": null
@@ -484,8 +530,12 @@
         "y_var",
         "group"
       ],
-      "numeric_fields": "x_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "x_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": null,
       "scale_hints": null
@@ -537,8 +587,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {},
       "scale_hints": {
@@ -556,7 +610,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -571,7 +627,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "pairwise_test"
@@ -608,7 +666,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -619,8 +679,12 @@
     "qq": {
       "kind": "composite",
       "renderer_type": false,
-      "required_mappings": "y_var",
-      "numeric_fields": "y_var",
+      "required_mappings": [
+        "y_var"
+      ],
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity"
       ],
@@ -635,7 +699,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "mean",
@@ -674,7 +740,9 @@
         "low_y",
         "high_y"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-categorical",
       "data_contract": {
         "x_var": {
@@ -708,8 +776,12 @@
         "category",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-waffle",
       "data_contract": {
         "category": {
@@ -729,8 +801,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -761,8 +837,12 @@
         "y_var",
         "group"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": {
         "x_var": {
@@ -793,8 +873,12 @@
         "axis",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-radar",
       "data_contract": {
         "axis": {
@@ -814,8 +898,12 @@
         "stage",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-funnel",
       "data_contract": {
         "stage": {
@@ -831,9 +919,13 @@
     "parallel": {
       "kind": "primitive",
       "renderer_type": true,
-      "required_mappings": "dimensions",
+      "required_mappings": [
+        "dimensions"
+      ],
       "numeric_fields": [],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-parallel",
       "data_contract": {
         "dimensions": {
@@ -853,7 +945,9 @@
         "time",
         "status"
       ],
-      "valid_transforms": "identity",
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": null,
       "scale_hints": null
@@ -861,9 +955,15 @@
     "histogram_fit": {
       "kind": "composite",
       "renderer_type": false,
-      "required_mappings": "value",
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "required_mappings": [
+        "value"
+      ],
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-binned",
       "data_contract": null,
       "scale_hints": null
@@ -875,8 +975,12 @@
         "date",
         "value"
       ],
-      "numeric_fields": "value",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "value"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "standalone-calendar",
       "data_contract": {
         "date": {
@@ -896,7 +1000,9 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
+      "numeric_fields": [
+        "y_var"
+      ],
       "valid_transforms": [
         "identity",
         "quantile_dots"
@@ -934,8 +1040,12 @@
         "x_var",
         "y_var"
       ],
-      "numeric_fields": "y_var",
-      "valid_transforms": "identity",
+      "numeric_fields": [
+        "y_var"
+      ],
+      "valid_transforms": [
+        "identity"
+      ],
       "group": "axes-continuous",
       "data_contract": null,
       "scale_hints": null
@@ -1138,7 +1248,9 @@
       "transform",
       "options"
     ],
-    "clear_duckdb_wasm_cache": "version",
+    "clear_duckdb_wasm_cache": [
+      "version"
+    ],
     "defineCategoricalAxis": [
       "myIO",
       "xAxis",
@@ -1177,9 +1289,15 @@
       "webgl_threshold",
       "unify_data_path"
     ],
-    "myio_chart_schema": "type",
-    "myio_function_signature": "fn",
-    "myIO_last_error": "outputId",
+    "myio_chart_schema": [
+      "type"
+    ],
+    "myio_function_signature": [
+      "fn"
+    ],
+    "myIO_last_error": [
+      "outputId"
+    ],
     "myio_list_chart_types": [],
     "myio_list_functions": [],
     "myio_validate_call": [

--- a/tests/js/mcp-validate.test.js
+++ b/tests/js/mcp-validate.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import {
+  validateSpec,
+  getChartSchema,
+  listChartTypes
+} from "../../mcp/lib/validate.mjs";
+
+// Regression guard for issue #52: single-mapping chart types had their
+// required_mappings serialized as a scalar string, so the validator iterated
+// the string character-by-character and reported a bogus MISSING_MAPPING per
+// letter. A minimal valid spec for every chart type must validate cleanly.
+describe("MCP validateSpec — every chart type accepts its minimal spec", function() {
+  for (const type of listChartTypes()) {
+    test(`${type} validates with its required mappings`, function() {
+      const schema = getChartSchema(type);
+      const mapping = {};
+      for (const field of schema.required_mappings) mapping[field] = field;
+      const transform = schema.valid_transforms[0] || "identity";
+
+      const result = validateSpec({ type, mapping, transform });
+
+      expect(schema.required_mappings.every((f) => typeof f === "string")).toBe(true);
+      expect(result).toEqual({ valid: true, errors: [] });
+    });
+  }
+});
+
+describe("MCP validateSpec — issue #52 repro", function() {
+  test("histogram with only `value` does not split the string into characters", function() {
+    const result = validateSpec({
+      type: "histogram",
+      mapping: { value: "mag" },
+      transform: "identity"
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("a genuinely missing single mapping reports exactly one error", function() {
+    const result = validateSpec({ type: "histogram", mapping: {}, transform: "identity" });
+    expect(result.valid).toBe(false);
+    const missing = result.errors.filter((e) => e.code === "MISSING_MAPPING");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].field).toBe("value");
+  });
+});

--- a/tools/build-myio-schema.mjs
+++ b/tools/build-myio-schema.mjs
@@ -60,6 +60,16 @@ function evaluateLiteral(expression) {
   return Function(`"use strict"; return (${expression});`)();
 }
 
+// dump-r-contracts.R serializes with jsonlite auto_unbox=TRUE, which renders a
+// length-1 vector (e.g. c("value")) as a scalar string. Downstream validators
+// iterate these fields and treat a string as iterable — splitting "value" into
+// v,a,l,u,e. Force every list-typed field back to an array here so the schema
+// is canonical and consumers never see a scalar.
+function asArray(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
 function readRendererContracts() {
   const files = fs.readdirSync(RENDERER_DIR)
     .filter((file) => file.endsWith("Renderer.js"))
@@ -85,18 +95,18 @@ export function buildSchema() {
     { cwd: ROOT, encoding: "utf8" }
   ));
   const renderers = readRendererContracts();
+  const composites = asArray(rContracts.composites);
   const types = {};
 
   for (const type of rContracts.allowed_types) {
     const renderer = renderers[type] || null;
-    const requiredMappings = rContracts.required_mappings[type] || [];
-    const numericFields = rContracts.numeric_fields[type] || [];
+    const validTransforms = asArray(rContracts.valid_combinations[type]);
     types[type] = {
-      kind: rContracts.composites.includes(type) ? "composite" : "primitive",
+      kind: composites.includes(type) ? "composite" : "primitive",
       renderer_type: Boolean(renderer),
-      required_mappings: requiredMappings,
-      numeric_fields: numericFields,
-      valid_transforms: rContracts.valid_combinations[type] || ["identity"],
+      required_mappings: asArray(rContracts.required_mappings[type]),
+      numeric_fields: asArray(rContracts.numeric_fields[type]),
+      valid_transforms: validTransforms.length ? validTransforms : ["identity"],
       group: rContracts.compatibility_groups[type] || "unknown",
       data_contract: renderer ? renderer.data_contract : null,
       scale_hints: renderer ? renderer.scale_hints : null
@@ -121,11 +131,14 @@ export function buildSchema() {
     ],
     types,
     renderer_types: Object.keys(renderers).sort(),
-    composites: rContracts.composites,
-    transforms: rContracts.transforms,
+    composites,
+    transforms: asArray(rContracts.transforms),
     compatibility_groups: rContracts.compatibility_groups,
     transform_input_contracts: rContracts.transform_input_contracts,
-    function_signatures: rContracts.function_signatures
+    function_signatures: Object.fromEntries(
+      Object.entries(rContracts.function_signatures)
+        .map(([fn, args]) => [fn, asArray(args)])
+    )
   };
 }
 


### PR DESCRIPTION
## Summary
Brings `main` current with 16 commits on `develop` (≈3 weeks of work). `main` has not advanced since 2026-05-05; pkgdown and R-CMD-check trigger on `main` only, so none of this is live or CRAN-checked on the release branch yet.

### Major features
- **LLM tool-calling** — schema + R tools + MCP server + usable, layered vignette (`cf6b088`, `4fb89dc`, `04a3a2d`, `583a5ee`)
- **Uncertainty visualizations** (`c19d352`); distribution axis-label and radar-axis fixes (`831974a`, `60d29b0`)
- **Accessibility** — `.myIO-sr-only` class (`abd6e82`)

### Fixes
- **#52: `validate_spec` rejected single-mapping charts** (`f25a243`) — schema generator now normalizes all list-typed fields to arrays; regression test covers every chart type. Unblocks single-mapping charts (histogram/gauge/qq) in the IONe-hosted Epicenter demo.
- AreaRenderer `boundaryStroke` default off (`84401e1`); Rd parse error (`0041aa2`); gallery chart-context (`4eba9ec`, `a9ad3b4`)
- CI: index new pkgdown topics; decouple schema-fresh test from R (`9761a8d`)

## Test plan
- [x] Full JS suite green (355 tests)
- [x] schema-fresh drift test passes against fresh Rscript generation
- [ ] R-CMD-check (--as-cran) passes on this PR (runs on push to main / PR)
- [ ] pkgdown builds and deploys after merge
- [ ] Confirm live docs serve the LLM tool-calling vignette (github.io; proxy deep-path 404 is a known infra issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)