### PR TITLE
test(touch): mobile/touch e2e verification (P4-4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,10 @@
 * End-to-end tests now run from a committed `playwright.config.ts` and a new
   `e2e` CI workflow. The suite builds and loads the minified `myIOapi.js`,
   guarding the production bundle that source-importing unit tests cannot catch.
+* Touch interaction is now verified end-to-end: a touch-emulation Playwright spec
+  on iOS- and Android-class viewports confirms a `touchstart` on a bar surfaces
+  the tooltip with the datum's content and `touchend` dismisses it, guarding the
+  mobile hover path against the production bundle.
 
 ## Improved error messages and API ergonomics
 

--- a/tests/playwright/fixtures/touch.html
+++ b/tests/playwright/fixtures/touch.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Classic <script src> loading of the built IIFE bundle (works over file://). -->
+  <script src="/inst/htmlwidgets/lib/d3.min.js"></script>
+  <script src="/inst/htmlwidgets/myIO/myIOapi.js"></script>
+</head>
+<body style="margin:0">
+  <div id="chart"></div>
+  <script>
+    // The htmlwidgets runtime provides this global in a real deployment; the
+    // shared hover handler reads HTMLWidgets.shinyMode. Stub it for the fixture.
+    window.HTMLWidgets = window.HTMLWidgets || { shinyMode: false };
+
+    function makeConfig(layers) {
+      return {
+        specVersion: 1,
+        layers: layers,
+        layout: { margin: { top: 30, bottom: 60, left: 50, right: 5 }, suppressLegend: false, suppressAxis: { xAxis: false, yAxis: false } },
+        scales: { xlim: { min: null, max: null }, ylim: { min: null, max: null }, categoricalScale: { xAxis: true, yAxis: false }, flipAxis: false, colorScheme: { colors: ["#4E79A7"], domain: ["B"], enabled: false } },
+        axes: { xAxisFormat: "s", yAxisFormat: "s", xAxisLabel: null, yAxisLabel: null, toolTipFormat: "s" },
+        interactions: { dragPoints: false, toggleY: { variable: null, format: null }, toolTipOptions: { suppressY: false } },
+        theme: {},
+        transitions: { speed: 0 },
+        referenceLines: { x: null, y: null }
+      };
+    }
+
+    function barLayer(data) {
+      return {
+        id: "layer_B", type: "bar", label: "B", data: data,
+        mapping: { x_var: "cat", y_var: "val" }, options: { barSize: "large" },
+        transform: "identity", transformMeta: {}, encoding: {}, sourceKey: "_source_key",
+        derivedFrom: null, order: 1, visibility: true, color: "#4E79A7"
+      };
+    }
+
+    window.__mountBars = function () {
+      d3.select("#chart").selectAll("*").remove();
+      window.__chart = new myIOchart({
+        element: document.getElementById("chart"),
+        config: makeConfig([barLayer([
+          { cat: "alpha", val: 30 }, { cat: "bravo", val: 55 }, { cat: "charlie", val: 18 }
+        ])]),
+        width: Math.min(window.innerWidth, 380), height: 300
+      });
+    };
+
+    window.__tooltipVisible = function () {
+      var t = document.querySelector(".toolTip");
+      return !!t && t.getAttribute("aria-hidden") === "false";
+    };
+    window.__tooltipText = function () {
+      var t = document.querySelector(".toolTip");
+      return t ? t.textContent : "";
+    };
+
+    window.__mountBars();
+    window.__myioTestReady = true;
+  </script>
+</body>
+</html>

--- a/tests/playwright/touch.spec.ts
+++ b/tests/playwright/touch.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+
+// P4-4 mobile/touch verification. Touch handlers are wired in rollover.js
+// (touchstart/move/end -> showElementHover -> tooltip) and tooltip.js. This
+// drives them on touch-enabled mobile viewports against the PRODUCTION bundle:
+// a touchstart over a bar must surface the tooltip (aria-hidden -> "false") with
+// the datum's content, and lifting must hide it again.
+
+let server: Server;
+let baseUrl: string;
+
+test.beforeAll(async () => {
+  server = createServer(async (req, res) => {
+    const pathname = decodeURIComponent(new URL(req.url || "/", "http://localhost").pathname);
+    const relative = normalize(pathname).replace(/^(\.\.[/\\])+/, "").replace(/^[/\\]/, "");
+    const filePath = join(process.cwd(), relative || "tests/playwright/fixtures/touch.html");
+    try {
+      const body = await readFile(filePath);
+      const type = extname(filePath) === ".js" ? "text/javascript" : "text/html";
+      res.writeHead(200, { "content-type": type });
+      res.end(body);
+    } catch (_) {
+      res.writeHead(404);
+      res.end("not found");
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function ready(page: Page) {
+  await page.goto(`${baseUrl}/tests/playwright/fixtures/touch.html`);
+  await page.waitForFunction(() => (window as any).__myioTestReady === true, null, { timeout: 10000 });
+}
+
+// Center of the first bar rect, in viewport coordinates, for touchscreen.tap.
+async function firstBarCenter(page: Page) {
+  const box = await page.locator("rect[class^='tag-bar']").first().boundingBox();
+  if (!box) throw new Error("no bar rect found");
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+const viewports = [
+  { name: "iOS (iPhone-class viewport)", viewport: { width: 390, height: 844 } },
+  { name: "Android (Pixel-class viewport)", viewport: { width: 393, height: 851 } }
+];
+
+for (const v of viewports) {
+  test.describe(v.name, () => {
+    test.use({ viewport: v.viewport, hasTouch: true, isMobile: true });
+
+    test("touchstart on a bar surfaces the tooltip; touchend hides it", async ({ page }) => {
+      await ready(page);
+      expect(await page.evaluate(() => (window as any).__tooltipVisible())).toBe(false);
+
+      const c = await firstBarCenter(page);
+
+      // Dispatch a real touchstart only, so we can observe the visible state
+      // before touchend schedules the 300ms hide (tap couples both events).
+      await page.evaluate(({ x, y }) => {
+        const bar = document.querySelector("rect[class^='tag-bar']") as Element;
+        const touch = new Touch({ identifier: 1, target: bar, clientX: x, clientY: y });
+        bar.dispatchEvent(new TouchEvent("touchstart", {
+          bubbles: true, cancelable: true, touches: [touch], changedTouches: [touch], targetTouches: [touch]
+        }));
+      }, c);
+
+      expect(await page.evaluate(() => (window as any).__tooltipVisible())).toBe(true);
+      const text = await page.evaluate(() => (window as any).__tooltipText());
+      expect(text).toContain("alpha"); // x_var value
+      expect(text).toContain("30");    // y_var value
+
+      // touchend hides it after the 300ms hide timer.
+      await page.evaluate(({ x, y }) => {
+        const bar = document.querySelector("rect[class^='tag-bar']") as Element;
+        const touch = new Touch({ identifier: 1, target: bar, clientX: x, clientY: y });
+        bar.dispatchEvent(new TouchEvent("touchend", {
+          bubbles: true, cancelable: true, touches: [], changedTouches: [touch], targetTouches: []
+        }));
+      }, c);
+      await page.waitForFunction(() => (window as any).__tooltipVisible() === false, null, { timeout: 5000 });
+    });
+
+    test("hasTouch context is active (no pointer-only fallback)", async ({ page }) => {
+      await ready(page);
+      const touchPoints = await page.evaluate(() => navigator.maxTouchPoints);
+      expect(touchPoints).toBeGreaterThan(0);
+    });
+  });
+}


### PR DESCRIPTION
## P4-4 — Mobile/touch verification (verify-only)

Touch is already wired (`rollover.js` touchstart/move/end → `showElementHover` → tooltip; `bottom-sheet.js` drag-to-dismiss; reduced-motion in `Chart.js`). This **ships the verification**, no product code change — no defect surfaced.

New `tests/playwright/touch.spec.ts` + `fixtures/touch.html` drive real `TouchEvent`s against the **production IIFE bundle** on touch-enabled iOS- and Android-class viewports (`hasTouch`, `isMobile`):

- `touchstart` on a bar surfaces the tooltip (`aria-hidden → "false"`) carrying the datum's x/y values.
- `touchend` dismisses it after the 300ms hide timer.
- `navigator.maxTouchPoints > 0` confirms the touch context is active (not a pointer-only fallback).

The fixture loads the bundle via classic `<script src>` and stubs the `HTMLWidgets` global the htmlwidgets runtime normally provides.

### Verification
`npx playwright test` → 17 passed, 1 pre-existing `fixme` skipped. `npm test` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)