### PR TITLE
fix(skills): gate checks inspect origin/main, never the local checkout

### DIFF
--- a/.agents/skills/backlog-pipeline/SKILL.md
+++ b/.agents/skills/backlog-pipeline/SKILL.md
@@ -5,6 +5,6 @@ description: Carry one human-approved myIO package issue through test-first impl
 
 # myIO backlog pipeline
 
-Require `backlog-ready`, non-red `main`, no open `automation-pr`, and an isolated worktree. Process one issue. Add a failing R, JavaScript, MCP, or integration contract before implementation as appropriate. Preserve myIO as the canonical engine and coordinate wrapper-visible behavior with pymyIO.
+Require `backlog-ready`, non-red `main`, no open `automation-pr`, and an isolated worktree. Evaluate every gate against remote state, never the local checkout: run `git fetch origin` first, and answer any merged/landed/shipped question with `git merge-base --is-ancestor <sha> origin/main` or `gh pr view <n> --json state` reporting `MERGED` — a commit appearing in bare `git log` proves nothing about `main`, because an unattended run may start on an unmerged feature branch. Process one issue. Add a failing R, JavaScript, MCP, or integration contract before implementation as appropriate. Preserve myIO as the canonical engine and coordinate wrapper-visible behavior with pymyIO.
 
 Run focused tests plus the repository's package, JavaScript, MCP, and documentation checks applicable to the change. Open one PR labeled `automation-pr` with provenance, `Closes #N`, commands/results, downstream compatibility risks, and unrun external gates. Stop before version bump, release, publication, or CRAN submission.

--- a/.agents/skills/idea-scout/SKILL.md
+++ b/.agents/skills/idea-scout/SKILL.md
@@ -5,6 +5,6 @@ description: Research myIO package, chart-engine, MCP, CRAN, compatibility, and 
 
 # myIO idea scout
 
-Read current package code, CRAN state, open issues, recent PRs, pymyIO compatibility constraints, and current primary dependency or ecosystem sources. Deduplicate every finding and propose the smallest testable change.
+Read current package code, CRAN state, open issues, recent PRs, pymyIO compatibility constraints, and current primary dependency or ecosystem sources. Deduplicate every finding and propose the smallest testable change. Verify any "already shipped/merged" claim against the remote, never the local checkout: `git fetch origin` first, then `git merge-base --is-ancestor <sha> origin/main` or `gh pr view <n> --json state` — bare `git log`, `HEAD`, or a commit merely existing locally is not evidence of shipping.
 
 When GitHub mutation is authorized, create `research-candidate` issues with sources, current gap, user value, compatibility impact, validation plan, and provenance. Never apply `backlog-ready`, modify code, bump a version, or begin a release.


### PR DESCRIPTION
## Problem

The 2026-07-13 unattended `backlog-pipeline` run evaluated its entry gates against the repo's current checkout, which happened to be `feature/legend-button-ui`, and concluded issue #84's work was "already merged to main as a200602" — false; that commit existed only on the feature branch. The skill's gate instructions never said which ref to check, so bare `git log` (i.e. HEAD) passed as evidence.

## Fix

Both `backlog-pipeline` and `idea-scout` gate/state checks now require:

1. `git fetch origin` before evaluating any gate.
2. "Is this merged?" answered only against the remote: `git merge-base --is-ancestor {sha} origin/main`, `git log origin/main`, or `gh pr view --json state` reporting `MERGED` / `gh pr list --base main --state merged`.
3. Bare `git log`, `git branch --show-current`, `HEAD`, or a commit merely existing locally are explicitly disallowed as merge evidence.

## Verification

Simulated from a non-main checkout with an unmerged empty commit (`54d932e`): the documented gate commands report it NOT merged, while bare `git log` sees it (the old false positive). Also confirmed `a200602` itself reports NOT merged via `git merge-base --is-ancestor`.

Note: the `feature/legend-button-ui` branch restructures these skills into `.agents/skills/` with symlinks; its copies will need the same language when that branch reconciles with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)